### PR TITLE
Add authentication flow with landing and auth pages

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,6 +1,7 @@
-import { Switch, Route } from "wouter";
+import { Switch, Route, Router } from "wouter";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { ThemeProvider } from "@/components/theme-provider";
+import { useEffect, type ReactNode } from "react";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { Toaster } from "@/components/ui/toaster";
 import { Sidebar } from "@/components/sidebar";
@@ -10,15 +11,72 @@ import Expenses from "@/pages/expenses";
 import Analytics from "@/pages/analytics";
 import Categories from "@/pages/categories";
 import NotFound from "@/pages/not-found";
+import Landing from "@/pages/landing";
+import Login from "@/pages/login";
+import Register from "@/pages/register";
+import { useCurrentUser } from "@/hooks/use-current-user";
+import { useLocation } from "wouter";
 
-function Router() {
+function LoadingScreen() {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-slate-50 to-slate-100">
+      <div className="h-12 w-12 animate-spin rounded-full border-4 border-primary border-t-transparent" />
+    </div>
+  );
+}
+
+function RequireAuth({ children }: { children: ReactNode }) {
+  const { data: user, isLoading } = useCurrentUser();
+  const [, setLocation] = useLocation();
+
+  useEffect(() => {
+    if (!isLoading && !user) {
+      setLocation("/login");
+    }
+  }, [isLoading, user, setLocation]);
+
+  if (isLoading) {
+    return <LoadingScreen />;
+  }
+
+  if (!user) {
+    return null;
+  }
+
+  return <>{children}</>;
+}
+
+function ProtectedApp() {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100">
+      <Sidebar />
+      <main className="min-h-screen lg:ml-64">
+        <Switch>
+          <Route path="/app/expenses" component={Expenses} />
+          <Route path="/app" component={Dashboard} />
+          <Route path="/app/analytics" component={Analytics} />
+          <Route path="/app/categories" component={Categories} />
+          <Route component={NotFound} />
+        </Switch>
+      </main>
+    </div>
+  );
+}
+
+function AppRoutes() {
   return (
     <Switch>
-      <Route path="/" component={Dashboard} />
-      <Route path="/expenses" component={Expenses} />
-      <Route path="/analytics" component={Analytics} />
-      <Route path="/categories" component={Categories} />
-      {/* Fallback to 404 */}
+      <Route path="/" component={Landing} />
+      <Route path="/login" component={Login} />
+      <Route path="/register" component={Register} />
+
+      <Route path="/app/:rest*">
+        {() => (
+          <RequireAuth>
+            <ProtectedApp />
+          </RequireAuth>
+        )}
+      </Route>
       <Route component={NotFound} />
     </Switch>
   );
@@ -42,7 +100,7 @@ function App() {
             <Sidebar />
             <main className="relative ml-0 flex min-h-screen flex-col px-6 pb-16 pt-16 transition-[margin] md:ml-[19rem] md:px-12">
               <div className="mx-auto w-full max-w-6xl">
-                <Router />
+                <AppRoutes />
               </div>
             </main>
           </div>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -48,16 +48,18 @@ function RequireAuth({ children }: { children: ReactNode }) {
 
 function ProtectedApp() {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100">
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100 text-foreground transition-colors duration-500 dark:from-slate-950 dark:via-slate-900 dark:to-indigo-950">
       <Sidebar />
-      <main className="min-h-screen lg:ml-64">
-        <Switch>
-          <Route path="/app/expenses" component={Expenses} />
-          <Route path="/app" component={Dashboard} />
-          <Route path="/app/analytics" component={Analytics} />
-          <Route path="/app/categories" component={Categories} />
-          <Route component={NotFound} />
-        </Switch>
+      <main className="relative ml-0 flex min-h-screen flex-col px-6 pb-16 pt-16 transition-[margin] md:ml-[19rem] md:px-12">
+        <div className="mx-auto w-full max-w-6xl">
+          <Switch>
+            <Route path="/expenses" component={Expenses} />
+            <Route path="/" component={Dashboard} />
+            <Route path="/analytics" component={Analytics} />
+            <Route path="/categories" component={Categories} />
+            <Route component={NotFound} />
+          </Switch>
+        </div>
       </main>
     </div>
   );
@@ -65,20 +67,20 @@ function ProtectedApp() {
 
 function AppRoutes() {
   return (
-    <Switch>
-      <Route path="/" component={Landing} />
-      <Route path="/login" component={Login} />
-      <Route path="/register" component={Register} />
+    <Router>
+      <Switch>
+        <Route path="/" component={Landing} />
+        <Route path="/login" component={Login} />
+        <Route path="/register" component={Register} />
 
-      <Route path="/app/:rest*">
-        {() => (
+        <Router base="/app">
           <RequireAuth>
             <ProtectedApp />
           </RequireAuth>
-        )}
-      </Route>
-      <Route component={NotFound} />
-    </Switch>
+        </Router>
+        <Route component={NotFound} />
+      </Switch>
+    </Router>
   );
 }
 
@@ -92,18 +94,7 @@ function App() {
         disableTransitionOnChange
       >
         <TooltipProvider>
-          <div className="relative min-h-screen bg-gradient-to-br from-slate-100 via-white to-purple-100 text-foreground transition-colors duration-500 dark:from-slate-950 dark:via-slate-900 dark:to-indigo-950">
-            <div className="pointer-events-none fixed inset-0 -z-10 overflow-hidden">
-              <div className="absolute -top-32 -right-20 h-72 w-72 rounded-full bg-primary/25 blur-3xl dark:bg-primary/30" />
-              <div className="absolute top-1/2 -left-32 h-96 w-96 -translate-y-1/2 rounded-full bg-purple-400/25 blur-3xl dark:bg-purple-500/20" />
-            </div>
-            <Sidebar />
-            <main className="relative ml-0 flex min-h-screen flex-col px-6 pb-16 pt-16 transition-[margin] md:ml-[19rem] md:px-12">
-              <div className="mx-auto w-full max-w-6xl">
-                <AppRoutes />
-              </div>
-            </main>
-          </div>
+          <AppRoutes />
           <Toaster />
         </TooltipProvider>
       </ThemeProvider>

--- a/client/src/components/sidebar.tsx
+++ b/client/src/components/sidebar.tsx
@@ -12,7 +12,6 @@ import {
 import { ThemeToggle } from "@/components/theme-toggle";
 import { Button } from "@/components/ui/button";
 import { useToast } from "@/hooks/use-toast";
-import { apiRequest } from "@/lib/queryClient";
 import { extractErrorMessage } from "@/lib/errors";
 import { useCurrentUser, currentUserQueryKey } from "@/hooks/use-current-user";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
@@ -29,9 +28,7 @@ export function Sidebar() {
   const { toast } = useToast();
 
   const logoutMutation = useMutation({
-    mutationFn: async () => {
-      await apiRequest("POST", "/api/auth/logout");
-    },
+    mutationFn: async () => {},
     onSuccess: () => {
       queryClient.setQueryData(currentUserQueryKey, null);
       queryClient.clear();
@@ -103,7 +100,7 @@ export function Sidebar() {
           </div>
         </div>
         <p className="text-center text-xs text-muted-foreground">
-          {"\u00A9"} {currentYear} DollarTrack
+          {"\u00A9"} {new Date().getFullYear()} DollarTrack
         </p>
       </div>
 
@@ -118,10 +115,9 @@ export function Sidebar() {
             size="sm"
             className="w-full justify-center gap-2"
             onClick={() => logoutMutation.mutate()}
-            disabled={logoutMutation.isLoading}
           >
             <LogOut className="h-4 w-4" />
-            {logoutMutation.isLoading ? "Logging out..." : "Logout"}
+            {"Logout"}
           </Button>
         </div>
       ) : null}

--- a/client/src/components/sidebar.tsx
+++ b/client/src/components/sidebar.tsx
@@ -8,17 +8,22 @@ import {
   LogOut,
   Settings,
   Sparkles,
+  KeyIcon,
+  SettingsIcon,
 } from "lucide-react";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { Button } from "@/components/ui/button";
 import { useToast } from "@/hooks/use-toast";
 import { extractErrorMessage } from "@/lib/errors";
+import { supabase } from "@/lib/supabase";
 import { useCurrentUser, currentUserQueryKey } from "@/hooks/use-current-user";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 const navigation = [
-  { name: "Dashboard", href: "/app", icon: LayoutDashboard },
-  { name: "Expenses", href: "/app/expenses", icon: CreditCard },
+  { name: "Dashboard", href: "/", icon: LayoutDashboard },
+  { name: "Expenses", href: "/expenses", icon: CreditCard },
+  { name: "Analytics", href: "/analytics", icon: KeyIcon },
+  { name: "Settings", href: "/settings", icon: SettingsIcon },
 ];
 
 export function Sidebar() {
@@ -28,7 +33,12 @@ export function Sidebar() {
   const { toast } = useToast();
 
   const logoutMutation = useMutation({
-    mutationFn: async () => {},
+    mutationFn: async () => {
+      const { error } = await supabase.auth.signOut();
+      if (error) {
+        throw error;
+      }
+    },
     onSuccess: () => {
       queryClient.setQueryData(currentUserQueryKey, null);
       queryClient.clear();

--- a/client/src/components/sidebar.tsx
+++ b/client/src/components/sidebar.tsx
@@ -5,40 +5,62 @@ import {
   LayoutDashboard,
   CreditCard,
   BarChart3,
-  Tag,
+  LogOut,
   Settings,
   Sparkles,
 } from "lucide-react";
 import { ThemeToggle } from "@/components/theme-toggle";
+import { Button } from "@/components/ui/button";
+import { useToast } from "@/hooks/use-toast";
+import { apiRequest } from "@/lib/queryClient";
+import { extractErrorMessage } from "@/lib/errors";
+import { useCurrentUser, currentUserQueryKey } from "@/hooks/use-current-user";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 const navigation = [
-  { name: "Dashboard", href: "/", icon: LayoutDashboard },
-  { name: "Expenses", href: "/expenses", icon: CreditCard },
-  { name: "Analytics", href: "/analytics", icon: BarChart3 },
-  { name: "Categories", href: "/categories", icon: Tag },
-  { name: "Settings", href: "/settings", icon: Settings },
+  { name: "Dashboard", href: "/app", icon: LayoutDashboard },
+  { name: "Expenses", href: "/app/expenses", icon: CreditCard },
 ];
 
 export function Sidebar() {
-  const currentYear = useMemo(() => new Date().getFullYear(), []);
+  const [location, setLocation] = useLocation();
+  const { data: user } = useCurrentUser();
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
 
-  const [location] = useLocation();
+  const logoutMutation = useMutation({
+    mutationFn: async () => {
+      await apiRequest("POST", "/api/auth/logout");
+    },
+    onSuccess: () => {
+      queryClient.setQueryData(currentUserQueryKey, null);
+      queryClient.clear();
+      toast({ title: "You have been logged out" });
+      setLocation("/login");
+    },
+    onError: (error: unknown) => {
+      toast({
+        title: "Unable to logout",
+        description: extractErrorMessage(error),
+        variant: "destructive",
+      });
+    },
+  });
 
   return (
-    <aside className="fixed inset-y-6 left-6 z-40 hidden w-64 flex-col justify-between overflow-hidden rounded-3xl border border-white/50 bg-sidebar backdrop-blur-2xl shadow-2xl transition-all duration-500 dark:border-white/10 md:flex">
-      <div className="relative px-6 pt-8">
-        <div className="pointer-events-none absolute -top-24 right-0 h-40 w-40 rounded-full bg-primary/30 blur-3xl dark:bg-primary/40" />
-        <div className="pointer-events-none absolute -bottom-14 left-1/2 h-32 w-32 -translate-x-1/2 rounded-full bg-purple-300/30 blur-3xl dark:bg-purple-500/30" />
-        <div className="relative flex items-center space-x-3">
-          <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-primary to-purple-500 text-white shadow-md">
-            <Sparkles className="h-6 w-6" />
+    <aside className="fixed left-0 top-0 z-50 flex h-full w-64 flex-col border-r border-border bg-white shadow-lg">
+      <div className="flex-1 p-6">
+        <div className="mb-8 flex items-center space-x-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-gradient-to-r from-purple-600 to-purple-700">
+            <BarChart3 className="h-6 w-6 text-white" />
           </div>
           <div>
-            <h1 className="text-lg font-semibold tracking-tight">ExpenseTracker</h1>
+            <h1 className="text-xl font-bold">DollarTrack</h1>
             <p className="text-sm text-muted-foreground">Smart Finance</p>
           </div>
         </div>
-        <nav className="mt-10 space-y-2">
+
+        <nav className="space-y-2">
           {navigation.map((item) => {
             const isActive = location === item.href;
             const Icon = item.icon;
@@ -54,12 +76,7 @@ export function Sidebar() {
                       : "text-muted-foreground hover:bg-secondary/80 hover:text-foreground"
                   )}
                 >
-                  <Icon
-                    className={cn(
-                      "h-5 w-5 transition-transform duration-300 group-hover:scale-105",
-                      isActive ? "text-primary-foreground" : "text-foreground/70"
-                    )}
-                  />
+                  <Icon className="h-5 w-5" />
                   <span>{item.name}</span>
                   {isActive ? (
                     <span className="ml-auto h-2 w-2 rounded-full bg-white/80" />
@@ -72,12 +89,16 @@ export function Sidebar() {
       </div>
       <div className="space-y-5 px-6 pb-8">
         <div className="rounded-3xl border border-white/40 bg-white/60 p-4 text-sm shadow-lg backdrop-blur-xl dark:border-white/10 dark:bg-slate-900/60">
-          <h3 className="mb-1 flex items-center gap-2 text-sm font-semibold">Upgrade Mode</h3>
+          <h3 className="mb-1 flex items-center gap-2 text-sm font-semibold">
+            Upgrade Mode
+          </h3>
           <p className="text-xs text-muted-foreground">
             Switch between light and dark experiences for a calmer focus.
           </p>
           <div className="mt-3 flex items-center justify-between">
-            <span className="text-xs font-medium text-muted-foreground">Theme</span>
+            <span className="text-xs font-medium text-muted-foreground">
+              Theme
+            </span>
             <ThemeToggle />
           </div>
         </div>
@@ -85,6 +106,25 @@ export function Sidebar() {
           {"\u00A9"} {currentYear} DollarTrack
         </p>
       </div>
+
+      {user ? (
+        <div className="border-t border-border p-6">
+          <div className="mb-3">
+            <p className="text-sm font-semibold text-foreground">{user.name}</p>
+            <p className="text-xs text-muted-foreground">{user.email}</p>
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            className="w-full justify-center gap-2"
+            onClick={() => logoutMutation.mutate()}
+            disabled={logoutMutation.isLoading}
+          >
+            <LogOut className="h-4 w-4" />
+            {logoutMutation.isLoading ? "Logging out..." : "Logout"}
+          </Button>
+        </div>
+      ) : null}
     </aside>
   );
 }

--- a/client/src/hooks/use-current-user.ts
+++ b/client/src/hooks/use-current-user.ts
@@ -1,0 +1,12 @@
+import { useQuery } from "@tanstack/react-query";
+import { getQueryFn } from "@/lib/queryClient";
+import type { PublicUser } from "@shared/schema";
+
+export const currentUserQueryKey = ["/api/auth/me"] as const;
+
+export function useCurrentUser() {
+  return useQuery<PublicUser | null>({
+    queryKey: currentUserQueryKey,
+    queryFn: getQueryFn({ on401: "returnNull" }),
+  });
+}

--- a/client/src/hooks/use-current-user.ts
+++ b/client/src/hooks/use-current-user.ts
@@ -1,11 +1,61 @@
 import { useQuery } from "@tanstack/react-query";
+import type { User as SupabaseUser } from "@supabase/supabase-js";
+
+import { supabase } from "@/lib/supabase";
 import type { PublicUser } from "@shared/schema";
 
 export const currentUserQueryKey = ["/api/auth/me"] as const;
 
+export function supabaseUserToPublicUser(user: SupabaseUser): PublicUser {
+  const metadata = (user.user_metadata ?? {}) as Record<string, unknown>;
+  const nameCandidates = [
+    metadata.name,
+    metadata.full_name,
+    metadata.display_name,
+  ];
+
+  const name =
+    nameCandidates.find(
+      (value): value is string =>
+        typeof value === "string" && value.trim().length > 0
+    ) ?? (user.email ? user.email.split("@")[0] : "User");
+
+  return {
+    id: user.id,
+    email: user.email ?? "",
+    name,
+  };
+}
+
+async function fetchCurrentUser(): Promise<PublicUser | null> {
+  const { data, error } = await supabase.auth.getUser();
+
+  if (error) {
+    // Supabase returns AuthSessionMissingError when no session is available.
+    if (
+      error.name === "AuthSessionMissingError" ||
+      (typeof error.message === "string" &&
+        error.message.toLowerCase().includes("session"))
+    ) {
+      return null;
+    }
+
+    throw error;
+  }
+
+  const user = data.user;
+  if (!user) {
+    return null;
+  }
+
+  return supabaseUserToPublicUser(user);
+}
+
 export function useCurrentUser() {
   return useQuery<PublicUser | null>({
     queryKey: currentUserQueryKey,
-    queryFn: () => {},
+    queryFn: fetchCurrentUser,
+    staleTime: Infinity,
+    gcTime: Infinity,
   });
 }

--- a/client/src/hooks/use-current-user.ts
+++ b/client/src/hooks/use-current-user.ts
@@ -1,5 +1,4 @@
 import { useQuery } from "@tanstack/react-query";
-import { getQueryFn } from "@/lib/queryClient";
 import type { PublicUser } from "@shared/schema";
 
 export const currentUserQueryKey = ["/api/auth/me"] as const;
@@ -7,6 +6,6 @@ export const currentUserQueryKey = ["/api/auth/me"] as const;
 export function useCurrentUser() {
   return useQuery<PublicUser | null>({
     queryKey: currentUserQueryKey,
-    queryFn: getQueryFn({ on401: "returnNull" }),
+    queryFn: () => {},
   });
 }

--- a/client/src/lib/errors.ts
+++ b/client/src/lib/errors.ts
@@ -1,0 +1,27 @@
+export function extractErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    const jsonMatch = error.message.match(/\{.*\}$/);
+    if (jsonMatch) {
+      try {
+        const parsed = JSON.parse(jsonMatch[0]);
+        if (parsed.message) {
+          return parsed.message as string;
+        }
+      } catch (parseError) {
+        console.error("Failed to parse error message", parseError);
+      }
+    }
+
+    const parts = error.message.split(": ");
+    if (parts.length > 1) {
+      return parts.slice(1).join(": ");
+    }
+    return error.message;
+  }
+
+  if (typeof error === "string") {
+    return error;
+  }
+
+  return "Something went wrong";
+}

--- a/client/src/pages/landing.tsx
+++ b/client/src/pages/landing.tsx
@@ -1,0 +1,148 @@
+import { Button } from "@/components/ui/button";
+import { ArrowRight, ShieldCheck, Sparkles, TrendingUp, Wallet } from "lucide-react";
+import { Link, useLocation } from "wouter";
+import { useMemo } from "react";
+
+const features = [
+  {
+    title: "Actionable insights",
+    description: "Understand your spending patterns with clear visualizations and personalized highlights.",
+    icon: TrendingUp,
+  },
+  {
+    title: "Secure by default",
+    description: "Your data stays private with encrypted sessions and privacy-first design decisions.",
+    icon: ShieldCheck,
+  },
+  {
+    title: "Made for everyday budgets",
+    description: "Organize expenses by category, set goals, and celebrate the wins that matter to you.",
+    icon: Wallet,
+  },
+];
+
+export default function Landing() {
+  const [, setLocation] = useLocation();
+  const currentYear = useMemo(() => new Date().getFullYear(), []);
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 text-white">
+      <header className="mx-auto flex max-w-6xl flex-col gap-6 px-6 py-6 md:flex-row md:items-center md:justify-between">
+        <div className="flex items-center gap-3">
+          <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-primary text-primary-foreground">
+            <Sparkles className="h-5 w-5" />
+          </div>
+          <div>
+            <p className="text-xs uppercase tracking-[0.3em] text-slate-300">DollarTrack</p>
+            <p className="text-sm text-slate-400">Budget smarter. Live better.</p>
+          </div>
+        </div>
+        <nav className="flex items-center gap-6 text-sm text-slate-300">
+          <a className="hidden transition hover:text-white md:inline" href="#features">
+            Features
+          </a>
+          <Link href="/login">
+            <a className="transition hover:text-white">Sign in</a>
+          </Link>
+          <Button size="sm" onClick={() => setLocation("/register")} className="gap-2">
+            Get started
+            <ArrowRight className="h-4 w-4" />
+          </Button>
+        </nav>
+      </header>
+
+      <main className="mx-auto flex max-w-6xl flex-col gap-20 px-6 pb-20 pt-10 md:pt-20">
+        <section className="grid gap-10 md:grid-cols-[1.1fr,0.9fr] md:items-center">
+          <div>
+            <div className="inline-flex items-center gap-2 rounded-full bg-white/10 px-4 py-1 text-sm font-medium text-slate-200">
+              <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-primary/20 text-primary">
+                <Sparkles className="h-3.5 w-3.5" />
+              </span>
+              Modern finance companion
+            </div>
+            <h1 className="mt-6 text-4xl font-semibold leading-tight tracking-tight text-white sm:text-5xl lg:text-6xl">
+              Take control of your spending with clarity and confidence.
+            </h1>
+            <p className="mt-6 max-w-xl text-lg text-slate-200">
+              DollarTrack helps you stay ahead of every transaction, forecast upcoming costs, and make decisions that align with
+              your goals.
+            </p>
+            <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+              <Button size="lg" className="gap-2" onClick={() => setLocation("/register")}>
+                Create free account
+                <ArrowRight className="h-4 w-4" />
+              </Button>
+              <Button
+                size="lg"
+                variant="outline"
+                className="border-white/20 bg-white/10 text-white hover:bg-white/20"
+                onClick={() => setLocation("/login")}
+              >
+                Sign in to dashboard
+              </Button>
+            </div>
+            <p className="mt-4 text-sm text-slate-300">
+              Try the demo account:&nbsp;
+              <span className="font-semibold">demo@dollartrack.app</span>
+              &nbsp;/&nbsp;
+              <span className="font-semibold">Password123!</span>
+            </p>
+          </div>
+
+          <div className="rounded-3xl border border-white/10 bg-white/5 p-6 shadow-2xl shadow-primary/30">
+            <div className="rounded-2xl border border-white/10 bg-slate-950/60 p-6">
+              <p className="text-sm uppercase tracking-[0.3em] text-primary">Weekly report</p>
+              <h2 className="mt-4 text-3xl font-semibold text-white">$2,840 saved this month</h2>
+              <p className="mt-3 text-sm text-slate-300">
+                Stay on track with digestible summaries, automated reminders, and beautifully simple analytics.
+              </p>
+              <div className="mt-6 grid gap-4 sm:grid-cols-2">
+                {features.map(feature => {
+                  const Icon = feature.icon;
+                  return (
+                    <div key={feature.title} className="rounded-xl border border-white/10 bg-white/5 p-4">
+                      <div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/20 text-primary">
+                        <Icon className="h-5 w-5" />
+                      </div>
+                      <p className="mt-4 text-sm font-semibold text-white">{feature.title}</p>
+                      <p className="mt-2 text-xs text-slate-300">{feature.description}</p>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section id="features" className="grid gap-6 md:grid-cols-3">
+          {features.map(feature => {
+            const Icon = feature.icon;
+            return (
+              <div key={feature.title} className="rounded-3xl border border-white/10 bg-white/5 p-6">
+                <div className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/20 text-primary">
+                  <Icon className="h-6 w-6" />
+                </div>
+                <h3 className="mt-6 text-xl font-semibold text-white">{feature.title}</h3>
+                <p className="mt-3 text-sm text-slate-300">{feature.description}</p>
+              </div>
+            );
+          })}
+        </section>
+      </main>
+
+      <footer className="border-t border-white/10 bg-slate-950/70">
+        <div className="mx-auto flex max-w-6xl flex-col items-center justify-between gap-4 px-6 py-6 text-sm text-slate-400 md:flex-row">
+          <p>© {currentYear} DollarTrack. All rights reserved.</p>
+          <div className="flex gap-6">
+            <a className="hover:text-white" href="#features">
+              Explore features
+            </a>
+            <a className="hover:text-white" href="mailto:hello@dollartrack.app">
+              Say hello
+            </a>
+          </div>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/client/src/pages/login.tsx
+++ b/client/src/pages/login.tsx
@@ -1,0 +1,132 @@
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { Link, useLocation } from "wouter";
+import { AlertCircle, Lock, Mail } from "lucide-react";
+import { z } from "zod";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { useToast } from "@/hooks/use-toast";
+import { apiRequest } from "@/lib/queryClient";
+import { extractErrorMessage } from "@/lib/errors";
+import { currentUserQueryKey } from "@/hooks/use-current-user";
+import { loginSchema, type PublicUser } from "@shared/schema";
+
+const formSchema = loginSchema;
+type LoginFormValues = z.infer<typeof formSchema>;
+
+export default function Login() {
+  const form = useForm<LoginFormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      email: "",
+      password: "",
+    },
+  });
+
+  const [formError, setFormError] = useState<string | null>(null);
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+  const [, setLocation] = useLocation();
+
+  const mutation = useMutation({
+    mutationFn: async (values: LoginFormValues) => {
+      const res = await apiRequest("POST", "/api/auth/login", values);
+      return (await res.json()) as PublicUser;
+    },
+    onSuccess: user => {
+      queryClient.setQueryData(currentUserQueryKey, user);
+      toast({ title: "Welcome back", description: `Good to see you, ${user.name}!` });
+      setFormError(null);
+      setLocation("/app");
+    },
+    onError: error => {
+      setFormError(extractErrorMessage(error));
+    },
+  });
+
+  const onSubmit = (values: LoginFormValues) => {
+    setFormError(null);
+    mutation.mutate(values);
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-slate-50 to-slate-100 px-4 py-16">
+      <Card className="w-full max-w-md shadow-xl">
+        <CardHeader className="space-y-1">
+          <CardTitle className="text-2xl font-bold">Welcome back</CardTitle>
+          <CardDescription>Sign in to access your finance dashboard.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form className="space-y-4" onSubmit={form.handleSubmit(onSubmit)} noValidate>
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-muted-foreground" htmlFor="email">
+                Email address
+              </label>
+              <div className="relative">
+                <Mail className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
+                <Input
+                  id="email"
+                  type="email"
+                  placeholder="you@email.com"
+                  autoComplete="email"
+                  className="pl-10"
+                  {...form.register("email")}
+                />
+              </div>
+              {form.formState.errors.email ? (
+                <p className="text-sm font-medium text-destructive">{form.formState.errors.email.message}</p>
+              ) : null}
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-muted-foreground" htmlFor="password">
+                Password
+              </label>
+              <div className="relative">
+                <Lock className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
+                <Input
+                  id="password"
+                  type="password"
+                  placeholder="••••••••"
+                  autoComplete="current-password"
+                  className="pl-10"
+                  {...form.register("password")}
+                />
+              </div>
+              {form.formState.errors.password ? (
+                <p className="text-sm font-medium text-destructive">{form.formState.errors.password.message}</p>
+              ) : null}
+            </div>
+
+            {formError ? (
+              <div className="flex items-center gap-2 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+                <AlertCircle className="h-4 w-4" />
+                <span>{formError}</span>
+              </div>
+            ) : null}
+
+            <Button type="submit" className="w-full" disabled={mutation.isLoading}>
+              {mutation.isLoading ? "Signing in..." : "Sign in"}
+            </Button>
+          </form>
+        </CardContent>
+        <CardFooter className="flex flex-col items-start gap-4 text-sm text-muted-foreground">
+          <div className="flex w-full items-center justify-between gap-2">
+            <span>New to DollarTrack?</span>
+            <Link href="/register">
+              <a className="font-medium text-primary hover:underline">Create an account</a>
+            </Link>
+          </div>
+          <p className="text-xs text-muted-foreground">
+            Demo account: <span className="font-medium text-foreground">demo@dollartrack.app</span> / {" "}
+            <span className="font-medium text-foreground">Password123!</span>
+          </p>
+        </CardFooter>
+      </Card>
+    </div>
+  );
+}

--- a/client/src/pages/login.tsx
+++ b/client/src/pages/login.tsx
@@ -7,10 +7,16 @@ import { AlertCircle, Lock, Mail } from "lucide-react";
 import { z } from "zod";
 
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { useToast } from "@/hooks/use-toast";
-import { apiRequest } from "@/lib/queryClient";
 import { extractErrorMessage } from "@/lib/errors";
 import { currentUserQueryKey } from "@/hooks/use-current-user";
 import { loginSchema, type PublicUser } from "@shared/schema";
@@ -34,16 +40,19 @@ export default function Login() {
 
   const mutation = useMutation({
     mutationFn: async (values: LoginFormValues) => {
-      const res = await apiRequest("POST", "/api/auth/login", values);
-      return (await res.json()) as PublicUser;
+      /*   const res = await apiRequest("POST", "/api/auth/login", values);
+      return (await res.json()) as PublicUser; */
     },
-    onSuccess: user => {
+    onSuccess: (user) => {
       queryClient.setQueryData(currentUserQueryKey, user);
-      toast({ title: "Welcome back", description: `Good to see you, ${user.name}!` });
+      toast({
+        title: "Welcome back",
+        description: `Good to see you, ${user.name}!`,
+      });
       setFormError(null);
       setLocation("/app");
     },
-    onError: error => {
+    onError: (error) => {
       setFormError(extractErrorMessage(error));
     },
   });
@@ -58,12 +67,21 @@ export default function Login() {
       <Card className="w-full max-w-md shadow-xl">
         <CardHeader className="space-y-1">
           <CardTitle className="text-2xl font-bold">Welcome back</CardTitle>
-          <CardDescription>Sign in to access your finance dashboard.</CardDescription>
+          <CardDescription>
+            Sign in to access your finance dashboard.
+          </CardDescription>
         </CardHeader>
         <CardContent>
-          <form className="space-y-4" onSubmit={form.handleSubmit(onSubmit)} noValidate>
+          <form
+            className="space-y-4"
+            onSubmit={form.handleSubmit(onSubmit)}
+            noValidate
+          >
             <div className="space-y-2">
-              <label className="text-sm font-medium text-muted-foreground" htmlFor="email">
+              <label
+                className="text-sm font-medium text-muted-foreground"
+                htmlFor="email"
+              >
                 Email address
               </label>
               <div className="relative">
@@ -78,12 +96,17 @@ export default function Login() {
                 />
               </div>
               {form.formState.errors.email ? (
-                <p className="text-sm font-medium text-destructive">{form.formState.errors.email.message}</p>
+                <p className="text-sm font-medium text-destructive">
+                  {form.formState.errors.email.message}
+                </p>
               ) : null}
             </div>
 
             <div className="space-y-2">
-              <label className="text-sm font-medium text-muted-foreground" htmlFor="password">
+              <label
+                className="text-sm font-medium text-muted-foreground"
+                htmlFor="password"
+              >
                 Password
               </label>
               <div className="relative">
@@ -98,7 +121,9 @@ export default function Login() {
                 />
               </div>
               {form.formState.errors.password ? (
-                <p className="text-sm font-medium text-destructive">{form.formState.errors.password.message}</p>
+                <p className="text-sm font-medium text-destructive">
+                  {form.formState.errors.password.message}
+                </p>
               ) : null}
             </div>
 
@@ -109,7 +134,11 @@ export default function Login() {
               </div>
             ) : null}
 
-            <Button type="submit" className="w-full" disabled={mutation.isLoading}>
+            <Button
+              type="submit"
+              className="w-full"
+              disabled={mutation.isLoading}
+            >
               {mutation.isLoading ? "Signing in..." : "Sign in"}
             </Button>
           </form>
@@ -118,12 +147,17 @@ export default function Login() {
           <div className="flex w-full items-center justify-between gap-2">
             <span>New to DollarTrack?</span>
             <Link href="/register">
-              <a className="font-medium text-primary hover:underline">Create an account</a>
+              <a className="font-medium text-primary hover:underline">
+                Create an account
+              </a>
             </Link>
           </div>
           <p className="text-xs text-muted-foreground">
-            Demo account: <span className="font-medium text-foreground">demo@dollartrack.app</span> / {" "}
-            <span className="font-medium text-foreground">Password123!</span>
+            Demo account:{" "}
+            <span className="font-medium text-foreground">
+              demo@dollartrack.app
+            </span>{" "}
+            / <span className="font-medium text-foreground">Password123!</span>
           </p>
         </CardFooter>
       </Card>

--- a/client/src/pages/register.tsx
+++ b/client/src/pages/register.tsx
@@ -7,10 +7,16 @@ import { Link, useLocation } from "wouter";
 import { AlertCircle, Lock, Mail, User as UserIcon } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { useToast } from "@/hooks/use-toast";
-import { apiRequest } from "@/lib/queryClient";
 import { extractErrorMessage } from "@/lib/errors";
 import { currentUserQueryKey } from "@/hooks/use-current-user";
 import { registerUserSchema, type PublicUser } from "@shared/schema";
@@ -19,7 +25,7 @@ const formSchema = registerUserSchema
   .extend({
     confirmPassword: z.string().min(8, "Please confirm your password"),
   })
-  .refine(values => values.password === values.confirmPassword, {
+  .refine((values) => values.password === values.confirmPassword, {
     message: "Passwords do not match",
     path: ["confirmPassword"],
   });
@@ -46,16 +52,19 @@ export default function Register() {
 
   const mutation = useMutation({
     mutationFn: async (values: RegisterPayload) => {
-      const res = await apiRequest("POST", "/api/auth/register", values);
-      return (await res.json()) as PublicUser;
+      /*     const res = await apiRequest("POST", "/api/auth/register", values);
+      return (await res.json()) as PublicUser; */
     },
-    onSuccess: user => {
+    onSuccess: (user) => {
       queryClient.setQueryData(currentUserQueryKey, user);
-      toast({ title: "Account created", description: `Welcome to DollarTrack, ${user.name}!` });
+      toast({
+        title: "Account created",
+        description: `Welcome to DollarTrack, ${user.name}!`,
+      });
       setFormError(null);
       setLocation("/app");
     },
-    onError: error => {
+    onError: (error) => {
       setFormError(extractErrorMessage(error));
     },
   });
@@ -70,13 +79,24 @@ export default function Register() {
     <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-slate-50 to-slate-100 px-4 py-16">
       <Card className="w-full max-w-lg shadow-xl">
         <CardHeader className="space-y-1">
-          <CardTitle className="text-2xl font-bold">Create your account</CardTitle>
-          <CardDescription>Get started with smarter money tracking in minutes.</CardDescription>
+          <CardTitle className="text-2xl font-bold">
+            Create your account
+          </CardTitle>
+          <CardDescription>
+            Get started with smarter money tracking in minutes.
+          </CardDescription>
         </CardHeader>
         <CardContent>
-          <form className="space-y-4" onSubmit={form.handleSubmit(onSubmit)} noValidate>
+          <form
+            className="space-y-4"
+            onSubmit={form.handleSubmit(onSubmit)}
+            noValidate
+          >
             <div className="space-y-2">
-              <label className="text-sm font-medium text-muted-foreground" htmlFor="name">
+              <label
+                className="text-sm font-medium text-muted-foreground"
+                htmlFor="name"
+              >
                 Full name
               </label>
               <div className="relative">
@@ -90,12 +110,17 @@ export default function Register() {
                 />
               </div>
               {form.formState.errors.name ? (
-                <p className="text-sm font-medium text-destructive">{form.formState.errors.name.message}</p>
+                <p className="text-sm font-medium text-destructive">
+                  {form.formState.errors.name.message}
+                </p>
               ) : null}
             </div>
 
             <div className="space-y-2">
-              <label className="text-sm font-medium text-muted-foreground" htmlFor="email">
+              <label
+                className="text-sm font-medium text-muted-foreground"
+                htmlFor="email"
+              >
                 Email address
               </label>
               <div className="relative">
@@ -110,12 +135,17 @@ export default function Register() {
                 />
               </div>
               {form.formState.errors.email ? (
-                <p className="text-sm font-medium text-destructive">{form.formState.errors.email.message}</p>
+                <p className="text-sm font-medium text-destructive">
+                  {form.formState.errors.email.message}
+                </p>
               ) : null}
             </div>
 
             <div className="space-y-2">
-              <label className="text-sm font-medium text-muted-foreground" htmlFor="password">
+              <label
+                className="text-sm font-medium text-muted-foreground"
+                htmlFor="password"
+              >
                 Password
               </label>
               <div className="relative">
@@ -130,14 +160,21 @@ export default function Register() {
                 />
               </div>
               {form.formState.errors.password ? (
-                <p className="text-sm font-medium text-destructive">{form.formState.errors.password.message}</p>
+                <p className="text-sm font-medium text-destructive">
+                  {form.formState.errors.password.message}
+                </p>
               ) : (
-                <p className="text-xs text-muted-foreground">Use at least 8 characters, mixing letters and numbers.</p>
+                <p className="text-xs text-muted-foreground">
+                  Use at least 8 characters, mixing letters and numbers.
+                </p>
               )}
             </div>
 
             <div className="space-y-2">
-              <label className="text-sm font-medium text-muted-foreground" htmlFor="confirmPassword">
+              <label
+                className="text-sm font-medium text-muted-foreground"
+                htmlFor="confirmPassword"
+              >
                 Confirm password
               </label>
               <div className="relative">
@@ -152,7 +189,9 @@ export default function Register() {
                 />
               </div>
               {form.formState.errors.confirmPassword ? (
-                <p className="text-sm font-medium text-destructive">{form.formState.errors.confirmPassword.message}</p>
+                <p className="text-sm font-medium text-destructive">
+                  {form.formState.errors.confirmPassword.message}
+                </p>
               ) : null}
             </div>
 
@@ -163,7 +202,11 @@ export default function Register() {
               </div>
             ) : null}
 
-            <Button type="submit" className="w-full" disabled={mutation.isLoading}>
+            <Button
+              type="submit"
+              className="w-full"
+              disabled={mutation.isLoading}
+            >
               {mutation.isLoading ? "Creating account..." : "Create account"}
             </Button>
           </form>
@@ -172,11 +215,14 @@ export default function Register() {
           <div className="flex w-full items-center justify-between gap-2">
             <span>Already have an account?</span>
             <Link href="/login">
-              <a className="font-medium text-primary hover:underline">Sign in</a>
+              <a className="font-medium text-primary hover:underline">
+                Sign in
+              </a>
             </Link>
           </div>
           <p className="text-xs text-muted-foreground">
-            By creating an account you agree to our imaginary terms and promise to stay awesome.
+            By creating an account you agree to our imaginary terms and promise
+            to stay awesome.
           </p>
         </CardFooter>
       </Card>

--- a/client/src/pages/register.tsx
+++ b/client/src/pages/register.tsx
@@ -1,0 +1,185 @@
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { Link, useLocation } from "wouter";
+import { AlertCircle, Lock, Mail, User as UserIcon } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { useToast } from "@/hooks/use-toast";
+import { apiRequest } from "@/lib/queryClient";
+import { extractErrorMessage } from "@/lib/errors";
+import { currentUserQueryKey } from "@/hooks/use-current-user";
+import { registerUserSchema, type PublicUser } from "@shared/schema";
+
+const formSchema = registerUserSchema
+  .extend({
+    confirmPassword: z.string().min(8, "Please confirm your password"),
+  })
+  .refine(values => values.password === values.confirmPassword, {
+    message: "Passwords do not match",
+    path: ["confirmPassword"],
+  });
+
+type RegisterFormValues = z.infer<typeof formSchema>;
+
+type RegisterPayload = Omit<RegisterFormValues, "confirmPassword">;
+
+export default function Register() {
+  const form = useForm<RegisterFormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      name: "",
+      email: "",
+      password: "",
+      confirmPassword: "",
+    },
+  });
+
+  const [formError, setFormError] = useState<string | null>(null);
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+  const [, setLocation] = useLocation();
+
+  const mutation = useMutation({
+    mutationFn: async (values: RegisterPayload) => {
+      const res = await apiRequest("POST", "/api/auth/register", values);
+      return (await res.json()) as PublicUser;
+    },
+    onSuccess: user => {
+      queryClient.setQueryData(currentUserQueryKey, user);
+      toast({ title: "Account created", description: `Welcome to DollarTrack, ${user.name}!` });
+      setFormError(null);
+      setLocation("/app");
+    },
+    onError: error => {
+      setFormError(extractErrorMessage(error));
+    },
+  });
+
+  const onSubmit = (values: RegisterFormValues) => {
+    setFormError(null);
+    const { confirmPassword, ...payload } = values;
+    mutation.mutate(payload);
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-slate-50 to-slate-100 px-4 py-16">
+      <Card className="w-full max-w-lg shadow-xl">
+        <CardHeader className="space-y-1">
+          <CardTitle className="text-2xl font-bold">Create your account</CardTitle>
+          <CardDescription>Get started with smarter money tracking in minutes.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form className="space-y-4" onSubmit={form.handleSubmit(onSubmit)} noValidate>
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-muted-foreground" htmlFor="name">
+                Full name
+              </label>
+              <div className="relative">
+                <UserIcon className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
+                <Input
+                  id="name"
+                  placeholder="Alex Johnson"
+                  autoComplete="name"
+                  className="pl-10"
+                  {...form.register("name")}
+                />
+              </div>
+              {form.formState.errors.name ? (
+                <p className="text-sm font-medium text-destructive">{form.formState.errors.name.message}</p>
+              ) : null}
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-muted-foreground" htmlFor="email">
+                Email address
+              </label>
+              <div className="relative">
+                <Mail className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
+                <Input
+                  id="email"
+                  type="email"
+                  placeholder="you@email.com"
+                  autoComplete="email"
+                  className="pl-10"
+                  {...form.register("email")}
+                />
+              </div>
+              {form.formState.errors.email ? (
+                <p className="text-sm font-medium text-destructive">{form.formState.errors.email.message}</p>
+              ) : null}
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-muted-foreground" htmlFor="password">
+                Password
+              </label>
+              <div className="relative">
+                <Lock className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
+                <Input
+                  id="password"
+                  type="password"
+                  placeholder="At least 8 characters"
+                  autoComplete="new-password"
+                  className="pl-10"
+                  {...form.register("password")}
+                />
+              </div>
+              {form.formState.errors.password ? (
+                <p className="text-sm font-medium text-destructive">{form.formState.errors.password.message}</p>
+              ) : (
+                <p className="text-xs text-muted-foreground">Use at least 8 characters, mixing letters and numbers.</p>
+              )}
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-muted-foreground" htmlFor="confirmPassword">
+                Confirm password
+              </label>
+              <div className="relative">
+                <Lock className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
+                <Input
+                  id="confirmPassword"
+                  type="password"
+                  placeholder="Repeat your password"
+                  autoComplete="new-password"
+                  className="pl-10"
+                  {...form.register("confirmPassword")}
+                />
+              </div>
+              {form.formState.errors.confirmPassword ? (
+                <p className="text-sm font-medium text-destructive">{form.formState.errors.confirmPassword.message}</p>
+              ) : null}
+            </div>
+
+            {formError ? (
+              <div className="flex items-center gap-2 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+                <AlertCircle className="h-4 w-4" />
+                <span>{formError}</span>
+              </div>
+            ) : null}
+
+            <Button type="submit" className="w-full" disabled={mutation.isLoading}>
+              {mutation.isLoading ? "Creating account..." : "Create account"}
+            </Button>
+          </form>
+        </CardContent>
+        <CardFooter className="flex flex-col items-start gap-4 text-sm text-muted-foreground">
+          <div className="flex w-full items-center justify-between gap-2">
+            <span>Already have an account?</span>
+            <Link href="/login">
+              <a className="font-medium text-primary hover:underline">Sign in</a>
+            </Link>
+          </div>
+          <p className="text-xs text-muted-foreground">
+            By creating an account you agree to our imaginary terms and promise to stay awesome.
+          </p>
+        </CardFooter>
+      </Card>
+    </div>
+  );
+}

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -1,0 +1,35 @@
+import { randomBytes, scryptSync, timingSafeEqual } from "crypto";
+import type { PublicUser, User } from "@shared/schema";
+
+const KEY_LENGTH = 64;
+
+export function hashPassword(password: string): string {
+  const salt = randomBytes(16).toString("hex");
+  const hash = scryptSync(password, salt, KEY_LENGTH).toString("hex");
+  return `${salt}:${hash}`;
+}
+
+export function verifyPassword(password: string, storedHash: string): boolean {
+  const [salt, key] = storedHash.split(":");
+  if (!salt || !key) {
+    return false;
+  }
+
+  const derivedKey = scryptSync(password, salt, KEY_LENGTH);
+  const storedKey = Buffer.from(key, "hex");
+
+  if (derivedKey.length !== storedKey.length) {
+    return false;
+  }
+
+  return timingSafeEqual(derivedKey, storedKey);
+}
+
+export function toPublicUser(user: User): PublicUser {
+  const { passwordHash, ...rest } = user;
+  return {
+    id: rest.id,
+    email: rest.email,
+    name: rest.name,
+  };
+}

--- a/server/config.ts
+++ b/server/config.ts
@@ -1,0 +1,2 @@
+export const SESSION_COOKIE_NAME = "dollartrack.sid";
+export const SESSION_MAX_AGE = 1000 * 60 * 60 * 24 * 7; // 7 days

--- a/server/types/express-session.d.ts
+++ b/server/types/express-session.d.ts
@@ -1,0 +1,7 @@
+import "express-session";
+
+declare module "express-session" {
+  interface SessionData {
+    userId?: string;
+  }
+}

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -3,6 +3,14 @@ import { pgTable, text, varchar, decimal, timestamp } from "drizzle-orm/pg-core"
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
+export const users = pgTable("users", {
+  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
+  email: varchar("email", { length: 255 }).notNull().unique(),
+  name: text("name").notNull(),
+  passwordHash: text("password_hash").notNull(),
+  createdAt: timestamp("created_at").notNull().default(sql`now()`),
+});
+
 export const categories = pgTable("categories", {
   id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
   name: text("name").notNull().unique(),
@@ -24,6 +32,11 @@ export const insertCategorySchema = createInsertSchema(categories).omit({
   id: true,
 });
 
+export const insertUserSchema = createInsertSchema(users).omit({
+  id: true,
+  createdAt: true,
+});
+
 export const insertExpenseSchema = createInsertSchema(expenses).omit({
   id: true,
   createdAt: true,
@@ -37,8 +50,25 @@ export const updateExpenseSchema = insertExpenseSchema.partial().extend({
   id: z.string(),
 });
 
+export const registerUserSchema = z.object({
+  name: z.string().min(2, "Name must be at least 2 characters"),
+  email: z.string().email("Please enter a valid email address"),
+  password: z.string().min(8, "Password must be at least 8 characters"),
+});
+
+export const loginSchema = z.object({
+  email: z.string().email("Please enter a valid email address"),
+  password: z.string().min(1, "Password is required"),
+});
+
 export type InsertCategory = z.infer<typeof insertCategorySchema>;
 export type Category = typeof categories.$inferSelect;
+
+export type InsertUser = z.infer<typeof insertUserSchema>;
+export type User = typeof users.$inferSelect;
+export type PublicUser = Pick<User, "id" | "email" | "name">;
+export type RegisterUserInput = z.infer<typeof registerUserSchema>;
+export type LoginInput = z.infer<typeof loginSchema>;
 
 export type InsertExpense = z.infer<typeof insertExpenseSchema>;
 export type UpdateExpense = z.infer<typeof updateExpenseSchema>;


### PR DESCRIPTION
## Summary
- configure express-session with a memory store and add server-side authentication routes backed by hashed passwords and user storage support
- extend the shared schema and client hooks for tracking the current user while updating the sidebar to surface profile details and logout
- introduce a marketing landing page plus login and registration screens and guard the dashboard behind authenticated routes

## Testing
- npm run build
- npm run lint *(fails: ESLint configuration missing in repo)*

------
https://chatgpt.com/codex/tasks/task_e_68c9dabe7ebc832194b95dffc7290546