### PR TITLE
Enhance dashboard styling

### DIFF
--- a/client/src/components/category-breakdown.tsx
+++ b/client/src/components/category-breakdown.tsx
@@ -1,6 +1,7 @@
 import { Link } from "wouter";
 import { useQuery } from "@tanstack/react-query";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
 import { getCategoryIcon } from "@/lib/categories";
 import { type Category } from "@shared/schema";
 import { fetchCategoryBreakdown } from "@/lib/api";
@@ -22,16 +23,17 @@ export function CategoryBreakdown() {
 
   if (isLoading) {
     return (
-      <Card>
+      <Card className="overflow-hidden border-transparent bg-gradient-to-br from-white/85 via-white/55 to-white/35 shadow-[0_24px_60px_rgba(15,23,42,0.08)] dark:from-slate-900/80 dark:via-slate-900/55 dark:to-slate-900/30">
         <CardHeader>
           <CardTitle>Category Breakdown</CardTitle>
         </CardHeader>
         <CardContent>
           <div className="space-y-4">
             {Array.from({ length: 5 }).map((_, i) => (
-              <div key={i} className="animate-pulse">
-                <div className="h-12 rounded bg-muted"></div>
-              </div>
+              <div
+                key={i}
+                className="h-16 w-full animate-pulse rounded-2xl bg-gradient-to-r from-white/60 via-white/30 to-white/50 dark:from-slate-900/60 dark:via-slate-900/40 dark:to-slate-900/50"
+              />
             ))}
           </div>
         </CardContent>
@@ -40,11 +42,16 @@ export function CategoryBreakdown() {
   }
 
   return (
-    <Card>
-      <CardHeader>
+    <Card className="relative overflow-hidden border-transparent bg-gradient-to-br from-white/85 via-white/55 to-white/30 shadow-[0_24px_60px_rgba(15,23,42,0.1)] dark:from-slate-900/80 dark:via-slate-900/55 dark:to-slate-900/30">
+      <span className="pointer-events-none absolute inset-x-10 -top-12 h-40 rounded-full bg-white/40 blur-3xl dark:bg-white/10" />
+      <span className="pointer-events-none absolute inset-x-16 bottom-0 h-32 rounded-full bg-white/30 blur-3xl dark:bg-white/10" />
+      <CardHeader className="relative z-10">
         <CardTitle>Category Breakdown</CardTitle>
+        <p className="text-sm text-muted-foreground">
+          Where your spending is concentrated this period
+        </p>
       </CardHeader>
-      <CardContent>
+      <CardContent className="relative z-10 space-y-6">
         {!breakdown || breakdown.length === 0 ? (
           <div className="py-8 text-center">
             <p className="text-muted-foreground">No expenses found</p>
@@ -56,30 +63,49 @@ export function CategoryBreakdown() {
           <div className="space-y-4">
             {breakdown.slice(0, 5).map((item) => {
               const Icon = getCategoryIcon(item.category.icon);
+              const progressWidth = Math.min(100, Math.max(0, item.percentage));
               return (
                 <div
                   key={item.category.id}
-                  className="flex items-center justify-between"
-                  data-testid={`category-${item.category.name.toLowerCase().replace(/\s+/g, '-')}`}
+                  className="group rounded-2xl border border-white/60 bg-white/75 p-4 shadow-sm backdrop-blur transition hover:-translate-y-1 hover:bg-white/90 dark:border-white/10 dark:bg-slate-900/60 dark:hover:bg-slate-900/70"
+                  data-testid={`category-${item.category.name
+                    .toLowerCase()
+                    .replace(/\s+/g, "-")}`}
                 >
-                  <div className="flex items-center space-x-3">
-                    <div
-                      className="flex h-10 w-10 items-center justify-center rounded-lg"
-                      style={{ backgroundColor: `${item.category.color}20` }}
-                    >
-                      <Icon className="h-5 w-5" style={{ color: item.category.color }} />
+                  <div className="flex flex-col gap-3">
+                    <div className="flex items-center justify-between gap-3">
+                      <div className="flex items-center gap-3">
+                        <div
+                          className="flex h-10 w-10 items-center justify-center rounded-xl"
+                          style={{
+                            backgroundColor: `${item.category.color}20`,
+                            color: item.category.color,
+                          }}
+                        >
+                          <Icon className="h-5 w-5" />
+                        </div>
+                        <div>
+                          <p className="text-sm font-semibold text-foreground">
+                            {item.category.name}
+                          </p>
+                          <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">
+                            {item.percentage.toFixed(1)}% of spend
+                          </p>
+                        </div>
+                      </div>
+                      <p className="text-sm font-semibold text-foreground">
+                        {formatCurrency(item.amount)}
+                      </p>
                     </div>
-                    <span className="text-sm font-medium text-foreground">
-                      {item.category.name}
-                    </span>
-                  </div>
-                  <div className="text-right">
-                    <p className="text-sm font-semibold text-foreground">
-                      {formatCurrency(item.amount)}
-                    </p>
-                    <p className="text-xs text-muted-foreground">
-                      {item.percentage.toFixed(1)}%
-                    </p>
+                    <div className="h-1.5 w-full rounded-full bg-muted/60">
+                      <span
+                        className="block h-full rounded-full"
+                        style={{
+                          width: `${progressWidth}%`,
+                          backgroundColor: item.category.color,
+                        }}
+                      />
+                    </div>
                   </div>
                 </div>
               );

--- a/client/src/components/expense-chart.tsx
+++ b/client/src/components/expense-chart.tsx
@@ -212,8 +212,10 @@ export function ExpenseChart() {
     : undefined;
 
   return (
-    <Card className="lg:col-span-2">
-      <CardHeader>
+    <Card className="relative overflow-hidden border-transparent bg-gradient-to-br from-white/90 via-white/55 to-white/30 shadow-[0_32px_70px_rgba(15,23,42,0.08)] transition-shadow hover:shadow-[0_36px_80px_rgba(15,23,42,0.12)] dark:from-slate-900/85 dark:via-slate-900/55 dark:to-slate-900/30 lg:col-span-2">
+      <span className="pointer-events-none absolute inset-x-10 -top-12 h-36 rounded-full bg-white/40 blur-3xl dark:bg-white/10" />
+      <span className="pointer-events-none absolute inset-x-16 bottom-0 h-32 rounded-full bg-white/30 blur-3xl dark:bg-white/10" />
+      <CardHeader className="relative z-10">
         <div className="flex flex-col space-y-4 lg:flex-row lg:items-center lg:justify-between lg:space-y-0">
           <CardTitle>Spending Overview</CardTitle>
           <div className="flex space-x-2">
@@ -221,7 +223,8 @@ export function ExpenseChart() {
               size="sm"
               variant={chartRange === "month" ? "default" : "ghost"}
               onClick={() => setChartRange("month")}
-              className="rounded-full px-4" data-testid="button-chart-month"
+              className="rounded-full border border-transparent px-4 shadow-sm hover:border-white/50 dark:hover:border-white/20"
+              data-testid="button-chart-month"
             >
               Month
             </Button>
@@ -229,7 +232,8 @@ export function ExpenseChart() {
               size="sm"
               variant={chartRange === "week" ? "default" : "ghost"}
               onClick={() => setChartRange("week")}
-              className="rounded-full px-4" data-testid="button-chart-week"
+              className="rounded-full border border-transparent px-4 shadow-sm hover:border-white/50 dark:hover:border-white/20"
+              data-testid="button-chart-week"
             >
               Week
             </Button>
@@ -237,28 +241,35 @@ export function ExpenseChart() {
               size="sm"
               variant={chartRange === "year" ? "default" : "ghost"}
               onClick={() => setChartRange("year")}
-              className="rounded-full px-4" data-testid="button-chart-year"
+              className="rounded-full border border-transparent px-4 shadow-sm hover:border-white/50 dark:hover:border-white/20"
+              data-testid="button-chart-year"
             >
               Year
             </Button>
           </div>
         </div>
       </CardHeader>
-      <CardContent>
+      <CardContent className="relative z-10 space-y-6">
         {isLoading ? (
-          <div className="h-80 rounded-lg border border-dashed border-muted-foreground/40 bg-muted/30 animate-pulse" />
+          <div className="h-80 animate-pulse rounded-3xl border border-dashed border-muted-foreground/30 bg-gradient-to-br from-white/60 via-white/40 to-white/20 dark:from-slate-900/60 dark:via-slate-900/40 dark:to-slate-900/30" />
         ) : !hasAnyExpenses ? (
-          <div className="h-80 flex flex-col items-center justify-center text-center space-y-2">
-            <p className="text-muted-foreground font-medium">No expenses yet</p>
+          <div className="flex h-80 flex-col items-center justify-center space-y-3 text-center">
+            <p className="text-base font-semibold text-foreground">No expenses yet</p>
             <p className="text-sm text-muted-foreground">
               Add your first expense to unlock spending insights.
             </p>
           </div>
         ) : (
           <>
-            <div className="mb-4 flex flex-col gap-2 text-sm text-muted-foreground md:flex-row md:items-center md:justify-between">
-              <span>{rangeSummary}</span>
-              {averageSummary ? <span>{averageSummary}</span> : null}
+            <div className="flex flex-col gap-3 text-sm text-muted-foreground md:flex-row md:items-center md:justify-between">
+              <span className="inline-flex items-center gap-2 rounded-full border border-white/60 bg-white/75 px-3 py-1 text-xs font-medium text-muted-foreground backdrop-blur dark:border-white/10 dark:bg-slate-900/60">
+                {rangeSummary}
+              </span>
+              {averageSummary ? (
+                <span className="inline-flex items-center gap-2 rounded-full border border-white/60 bg-white/75 px-3 py-1 text-xs font-medium text-muted-foreground backdrop-blur dark:border-white/10 dark:bg-slate-900/60">
+                  {averageSummary}
+                </span>
+              ) : null}
             </div>
             <div className="relative h-80">
               <ResponsiveContainer width="100%" height="100%">
@@ -269,7 +280,7 @@ export function ExpenseChart() {
                       <stop offset="95%" stopColor="#7c3aed" stopOpacity={0.05} />
                     </linearGradient>
                   </defs>
-                  <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="#E5E7EB" />
+                  <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="rgba(148, 163, 184, 0.35)" />
                   <XAxis
                     dataKey="label"
                     stroke="currentColor"

--- a/client/src/components/recent-expenses.tsx
+++ b/client/src/components/recent-expenses.tsx
@@ -96,8 +96,10 @@ export function RecentExpenses() {
   };
 
   return (
-    <Card>
-      <CardHeader className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+    <Card className="relative overflow-hidden border-transparent bg-gradient-to-br from-white/90 via-white/55 to-white/30 shadow-[0_28px_60px_rgba(15,23,42,0.08)] dark:from-slate-900/85 dark:via-slate-900/55 dark:to-slate-900/30">
+      <span className="pointer-events-none absolute inset-x-8 -top-12 h-32 rounded-full bg-white/40 blur-3xl dark:bg-white/10" />
+      <span className="pointer-events-none absolute inset-x-12 bottom-0 h-32 rounded-full bg-white/30 blur-3xl dark:bg-white/10" />
+      <CardHeader className="relative z-10 flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
         <div>
           <CardTitle>Recent Expenses</CardTitle>
           <p className="mt-1 text-sm text-muted-foreground">
@@ -111,28 +113,28 @@ export function RecentExpenses() {
               placeholder="Search expenses..."
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
-              className="pl-11"
+              className="rounded-full border border-white/60 bg-white/80 pl-11 pr-4 text-sm shadow-sm backdrop-blur transition focus-visible:ring-1 dark:border-white/10 dark:bg-slate-900/60"
               data-testid="input-search-expenses"
             />
-            <Search className="absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+            <Search className="pointer-events-none absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
           </div>
           <Button
             variant="ghost"
             size="sm"
-            className="rounded-full px-4"
+            className="rounded-full border border-white/60 bg-white/75 px-4 text-xs font-semibold text-foreground backdrop-blur transition hover:bg-white/90 dark:border-white/10 dark:bg-slate-900/60 dark:hover:bg-slate-900/70"
             data-testid="button-view-all-expenses"
           >
             View All
           </Button>
         </div>
       </CardHeader>
-      <CardContent>
+      <CardContent className="relative z-10">
         {isLoading ? (
           <div className="space-y-4">
             {Array.from({ length: 3 }).map((_, i) => (
               <div
                 key={i}
-                className="h-20 w-full animate-pulse rounded-2xl bg-white/50 backdrop-blur dark:bg-slate-900/60"
+                className="h-20 w-full animate-pulse rounded-2xl bg-gradient-to-r from-white/60 via-white/35 to-white/55 backdrop-blur dark:from-slate-900/60 dark:via-slate-900/40 dark:to-slate-900/50"
               />
             ))}
           </div>
@@ -154,7 +156,7 @@ export function RecentExpenses() {
               return (
                 <div
                   key={expense.id}
-                  className="expense-card flex items-center justify-between rounded-2xl border border-white/50 bg-white/75 p-5 shadow-sm backdrop-blur-xl dark:border-white/10 dark:bg-slate-900/60"
+                  className="expense-card flex items-center justify-between rounded-2xl border border-white/60 bg-white/80 p-5 shadow-sm backdrop-blur-xl transition hover:-translate-y-1 hover:bg-white/90 dark:border-white/10 dark:bg-slate-900/60 dark:hover:bg-slate-900/70"
                   data-testid={`expense-item-${expense.id}`}
                 >
                   <div className="flex items-center gap-4">
@@ -167,7 +169,7 @@ export function RecentExpenses() {
                     >
                       <Icon className="h-5 w-5" />
                     </div>
-                    <div>
+                    <div className="space-y-1">
                       <p className="text-base font-semibold text-foreground">
                         {expense.description}
                       </p>
@@ -179,20 +181,25 @@ export function RecentExpenses() {
                   <div className="flex items-center gap-4">
                     <Badge
                       variant="secondary"
-                      className="rounded-full border border-white/50 bg-white/70 px-3 py-1 text-xs font-semibold text-muted-foreground backdrop-blur dark:border-white/10 dark:bg-slate-900/60"
+                      className="rounded-full border border-white/60 bg-white/75 px-3 py-1 text-xs font-semibold text-muted-foreground backdrop-blur dark:border-white/10 dark:bg-slate-900/60"
                       style={{ color: expense.category.color }}
                     >
                       {expense.category.name}
                     </Badge>
-                    <p className="text-lg font-semibold text-foreground">
-                      -{formatCurrency(expense.amount)}
-                    </p>
+                    <div className="text-right">
+                      <p className="text-lg font-semibold text-foreground">
+                        -{formatCurrency(expense.amount)}
+                      </p>
+                      <p className="text-[10px] uppercase tracking-[0.3em] text-muted-foreground">
+                        {expense.category.name}
+                      </p>
+                    </div>
                     <div className="flex gap-1">
                       <EditExpenseModal expense={expense}>
                         <Button
                           size="icon"
                           variant="ghost"
-                          className="h-9 w-9 rounded-full"
+                          className="h-9 w-9 rounded-full border border-transparent text-muted-foreground hover:border-white/60 hover:text-foreground dark:hover:border-white/20"
                           data-testid={`button-edit-expense-${expense.id}`}
                         >
                           <Edit2 className="h-4 w-4" />
@@ -201,7 +208,7 @@ export function RecentExpenses() {
                       <Button
                         size="icon"
                         variant="ghost"
-                        className="h-9 w-9 rounded-full text-muted-foreground hover:text-destructive"
+                        className="h-9 w-9 rounded-full border border-transparent text-muted-foreground transition hover:border-white/60 hover:text-destructive dark:hover:border-white/20"
                         onClick={() => handleDeleteExpense(expense.id)}
                         disabled={deleteExpenseMutation.isPending}
                         data-testid={`button-delete-expense-${expense.id}`}

--- a/client/src/components/stats-cards.tsx
+++ b/client/src/components/stats-cards.tsx
@@ -85,7 +85,10 @@ export function StatsCards({}: StatsCardsProps) {
     return (
       <div className="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-4">
         {Array.from({ length: 4 }).map((_, i) => (
-          <Card key={i} className="h-36 animate-pulse rounded-3xl bg-white/60 dark:bg-slate-900/60" />
+          <Card
+            key={i}
+            className="h-40 animate-pulse rounded-[2rem] border-transparent bg-gradient-to-br from-white/80 via-white/50 to-white/30 dark:from-slate-900/70 dark:via-slate-900/45 dark:to-slate-900/30"
+          />
         ))}
       </div>
     );
@@ -166,44 +169,50 @@ export function StatsCards({}: StatsCardsProps) {
       {stats.map((stat) => {
         const Icon = stat.icon;
         return (
-          <Card key={stat.title} className="relative overflow-hidden">
+          <Card
+            key={stat.title}
+            className={cn(
+              "relative overflow-hidden border-transparent bg-gradient-to-br from-white/85 via-white/50 to-white/25 shadow-[0_28px_55px_rgba(124,58,237,0.14)] transition-all hover:translate-y-[-2px] hover:shadow-[0_32px_65px_rgba(124,58,237,0.18)] dark:from-slate-900/80 dark:via-slate-900/55 dark:to-slate-900/30",
+              "card-hover"
+            )}
+          >
             <span
               className={cn(
                 "pointer-events-none absolute inset-0 bg-gradient-to-br opacity-80",
                 stat.accent
               )}
             />
-            <CardContent className="relative z-10 space-y-6">
+            <span className="pointer-events-none absolute inset-x-6 -top-6 h-24 rounded-full bg-white/40 blur-3xl dark:bg-white/10" />
+            <span className="pointer-events-none absolute inset-x-8 bottom-0 h-24 rounded-full bg-white/30 blur-3xl dark:bg-white/10" />
+            <CardContent className="relative z-10 space-y-6 px-6 py-6 sm:px-8">
               <div className="flex items-center justify-between">
                 <div>
-                  <p className="text-xs font-semibold uppercase tracking-[0.24em] text-muted-foreground">
+                  <p className="text-xs font-semibold uppercase tracking-[0.28em] text-muted-foreground">
                     {stat.title}
                   </p>
                   <p
-                    className="mt-3 text-3xl font-semibold text-foreground"
+                    className="mt-3 text-4xl font-semibold text-foreground"
                     data-testid={stat.testId}
                   >
                     {stat.value}
                   </p>
                 </div>
-                <div className="relative flex h-14 w-14 items-center justify-center rounded-2xl border border-white/60 bg-white/70 shadow-md shadow-black/5 dark:border-white/10 dark:bg-slate-900/70">
+                <div className="relative flex h-14 w-14 items-center justify-center rounded-2xl border border-white/60 bg-white/80 shadow-inner shadow-primary/10 dark:border-white/10 dark:bg-slate-900/70">
                   <span
                     className={cn(
-                      "absolute inset-0 rounded-2xl bg-gradient-to-br opacity-80", 
+                      "absolute inset-0 rounded-2xl bg-gradient-to-br opacity-80",
                       stat.accent
                     )}
                   />
                   <Icon className={cn("relative z-10 h-6 w-6", stat.iconColor)} />
                 </div>
               </div>
-              <div className="space-y-2 text-sm">
-                <div className="flex items-center space-x-2">
+              <div className="space-y-3 text-sm">
+                <div className="inline-flex items-center gap-2 rounded-full border border-white/60 bg-white/75 px-3 py-1 text-xs font-medium text-muted-foreground backdrop-blur dark:border-white/10 dark:bg-slate-900/60">
                   <span className={cn("font-semibold", stat.trendColor)}>
                     {stat.trendValue}
                   </span>
-                  <span className="text-muted-foreground">
-                    {stat.trendDescriptor}
-                  </span>
+                  <span>{stat.trendDescriptor}</span>
                 </div>
                 {stat.meta ? (
                   <p className="text-xs text-muted-foreground">{stat.meta}</p>

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -16,24 +16,33 @@ export default function Dashboard() {
   });
 
   return (
-    <div className="space-y-10 pb-12">
-      <section className="relative overflow-hidden rounded-3xl border border-white/40 bg-gradient-to-br from-white/80 via-white/60 to-purple-100/50 px-8 py-10 shadow-2xl backdrop-blur-2xl transition-colors dark:border-white/10 dark:from-slate-900/80 dark:via-slate-900/50 dark:to-indigo-900/40">
-        <div className="pointer-events-none absolute -top-20 right-0 h-56 w-56 rounded-full bg-primary/30 blur-3xl dark:bg-primary/40" />
-        <div className="pointer-events-none absolute bottom-0 left-1/2 h-64 w-64 -translate-x-1/2 rounded-full bg-purple-400/25 blur-3xl dark:bg-purple-500/25" />
-        <div className="relative flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
-          <div>
-            <p className="text-xs font-semibold uppercase tracking-[0.35em] text-muted-foreground">
+    <div className="relative space-y-10 pb-12">
+      <div className="pointer-events-none absolute inset-x-0 -top-32 h-72 bg-gradient-to-b from-primary/15 via-transparent to-transparent dark:from-primary/20" />
+      <div className="pointer-events-none absolute -bottom-32 left-1/2 h-72 w-[90%] -translate-x-1/2 rounded-[6rem] bg-gradient-to-r from-indigo-300/15 via-primary/10 to-purple-300/15 blur-3xl dark:from-indigo-500/20 dark:via-primary/15 dark:to-purple-500/20" />
+
+      <section className="relative overflow-hidden rounded-[2.25rem] border border-white/50 bg-gradient-to-br from-white/90 via-white/60 to-white/30 px-8 py-10 shadow-2xl shadow-primary/10 backdrop-blur-3xl transition-colors dark:border-white/10 dark:from-slate-900/90 dark:via-slate-900/60 dark:to-slate-900/30">
+        <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(124,58,237,0.18),_transparent_60%)] dark:bg-[radial-gradient(circle_at_top,_rgba(129,140,248,0.25),_transparent_65%)]" />
+        <div className="pointer-events-none absolute -top-28 -left-16 h-64 w-64 rounded-full bg-primary/25 blur-3xl dark:bg-primary/40" />
+        <div className="pointer-events-none absolute -bottom-32 right-0 h-72 w-72 rounded-full bg-purple-400/20 blur-3xl dark:bg-purple-500/25" />
+        <div className="relative flex flex-col gap-8 md:flex-row md:items-center md:justify-between">
+          <div className="space-y-5">
+            <span className="inline-flex items-center gap-2 rounded-full border border-white/60 bg-white/70 px-4 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-muted-foreground backdrop-blur dark:border-white/10 dark:bg-slate-900/70">
               Smart finance overview
-            </p>
-            <h2 className="mt-3 text-4xl font-semibold text-foreground">Dashboard</h2>
-            <p className="mt-3 text-sm text-muted-foreground" data-testid="current-date">
-              Today is {currentDate}
+            </span>
+            <div className="space-y-3">
+              <h2 className="text-4xl font-semibold text-foreground md:text-5xl">Dashboard</h2>
+              <p className="text-sm text-muted-foreground" data-testid="current-date">
+                Today is {currentDate}
+              </p>
+            </div>
+            <p className="max-w-xl text-sm text-muted-foreground/80">
+              Track your spending, understand where your money goes, and make confident financial decisions with a refined, data-driven overview.
             </p>
           </div>
           <div className="flex flex-wrap items-center gap-3">
             <Button
               variant="outline"
-              className="gap-2"
+              className="gap-2 rounded-full border-white/50 bg-white/70 px-5 text-foreground shadow-sm backdrop-blur hover:bg-white/90 dark:border-white/10 dark:bg-slate-900/60 dark:hover:bg-slate-900/70"
               data-testid="button-filter"
             >
               <Filter className="h-4 w-4" />


### PR DESCRIPTION
## Summary
- refresh the dashboard hero with layered gradients, improved copy, and polished controls
- restyle the stats, chart, category breakdown, and recent expenses cards for a cohesive glassmorphism aesthetic and clearer data presentation
- add progress visuals and refined interactions within cards to make analytics easier to scan

## Testing
- `npm run build`
- `npm run lint` *(fails: ESLint configuration missing in project)*

------
https://chatgpt.com/codex/tasks/task_e_68c9eab567b08321a6e58047e1d013e6