### PR TITLE
Add shared expense filters

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -16,6 +16,7 @@ import Login from "@/pages/login";
 import Register from "@/pages/register";
 import { useCurrentUser } from "@/hooks/use-current-user";
 import { useLocation } from "wouter";
+import { ExpenseFiltersProvider } from "@/hooks/use-expense-filters";
 
 function LoadingScreen() {
   return (
@@ -94,7 +95,10 @@ function App() {
         disableTransitionOnChange
       >
         <TooltipProvider>
-          <AppRoutes />
+          <ExpenseFiltersProvider>
+            <AppRoutes />
+          </ExpenseFiltersProvider>
+
           <Toaster />
         </TooltipProvider>
       </ThemeProvider>

--- a/client/src/components/active-expense-filters.tsx
+++ b/client/src/components/active-expense-filters.tsx
@@ -1,0 +1,110 @@
+import { useMemo } from "react";
+import { X } from "lucide-react";
+import { useQuery } from "@tanstack/react-query";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { fetchCategories } from "@/lib/api";
+import { useExpenseFilters } from "@/hooks/use-expense-filters";
+import type { Category } from "@shared/schema";
+
+const formatDate = (date: Date) =>
+  date.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+
+type ActiveExpenseFiltersProps = {
+  className?: string;
+};
+
+export function ActiveExpenseFilters({
+  className,
+}: ActiveExpenseFiltersProps) {
+  const { filters, setFilters, resetFilters } = useExpenseFilters();
+  const { data: categories } = useQuery<Category[]>({
+    queryKey: ["categories"],
+    queryFn: fetchCategories,
+  });
+
+  const categoryMap = useMemo(() => {
+    const map = new Map<string, Category>();
+    for (const category of categories ?? []) {
+      map.set(category.id, category);
+    }
+    return map;
+  }, [categories]);
+
+  const hasCategoryFilters = filters.categories.length > 0;
+  const hasDateFilter = Boolean(filters.dateRange?.from || filters.dateRange?.to);
+
+  if (!hasCategoryFilters && !hasDateFilter) {
+    return null;
+  }
+
+  const removeCategory = (categoryId: string) => {
+    setFilters((previous) => ({
+      ...previous,
+      categories: previous.categories.filter((id) => id !== categoryId),
+    }));
+  };
+
+  const clearDate = () => {
+    setFilters((previous) => ({ ...previous, dateRange: undefined }));
+  };
+
+  const rangeLabel = (() => {
+    if (!filters.dateRange) return "";
+    const { from, to } = filters.dateRange;
+    if (from && to) {
+      return `${formatDate(from)} – ${formatDate(to)}`;
+    }
+    if (from) {
+      return `From ${formatDate(from)}`;
+    }
+    if (to) {
+      return `Until ${formatDate(to)}`;
+    }
+    return "";
+  })();
+
+  return (
+    <div className={cn("flex flex-wrap items-center gap-2", className)}>
+      {filters.categories.map((categoryId) => {
+        const category = categoryMap.get(categoryId);
+        return (
+          <button
+            key={categoryId}
+            type="button"
+            onClick={() => removeCategory(categoryId)}
+            className="inline-flex items-center gap-2 rounded-full border border-white/50 bg-white/80 px-3 py-1 text-xs font-medium text-muted-foreground shadow-sm transition hover:border-primary/40 hover:text-primary focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-1 dark:border-white/10 dark:bg-slate-900/60"
+          >
+            <span>{category?.name ?? "Category"}</span>
+            <X className="h-3 w-3" aria-hidden="true" />
+          </button>
+        );
+      })}
+
+      {hasDateFilter && rangeLabel && (
+        <button
+          type="button"
+          onClick={clearDate}
+          className="inline-flex items-center gap-2 rounded-full border border-white/50 bg-white/80 px-3 py-1 text-xs font-medium text-muted-foreground shadow-sm transition hover:border-primary/40 hover:text-primary focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-1 dark:border-white/10 dark:bg-slate-900/60"
+        >
+          <span>{rangeLabel}</span>
+          <X className="h-3 w-3" aria-hidden="true" />
+        </button>
+      )}
+
+      <Button
+        variant="ghost"
+        size="sm"
+        className="h-8 rounded-full px-3 text-xs"
+        onClick={resetFilters}
+      >
+        Clear all
+      </Button>
+    </div>
+  );
+}
+

--- a/client/src/hooks/use-expense-filters.tsx
+++ b/client/src/hooks/use-expense-filters.tsx
@@ -1,0 +1,57 @@
+import { createContext, useContext, useMemo, useState } from "react";
+import type { ReactNode } from "react";
+import type { DateRange } from "react-day-picker";
+
+export type ExpenseFilters = {
+  categories: string[];
+  dateRange?: DateRange;
+};
+
+type ExpenseFiltersContextValue = {
+  filters: ExpenseFilters;
+  setFilters: React.Dispatch<React.SetStateAction<ExpenseFilters>>;
+  resetFilters: () => void;
+};
+
+const ExpenseFiltersContext = createContext<ExpenseFiltersContextValue | null>(
+  null
+);
+
+const createDefaultFilters = (): ExpenseFilters => ({
+  categories: [],
+  dateRange: undefined,
+});
+
+export function ExpenseFiltersProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const [filters, setFilters] = useState<ExpenseFilters>(createDefaultFilters);
+
+  const value = useMemo(() => {
+    const resetFilters = () => setFilters(createDefaultFilters());
+    return {
+      filters,
+      setFilters,
+      resetFilters,
+    };
+  }, [filters]);
+
+  return (
+    <ExpenseFiltersContext.Provider value={value}>
+      {children}
+    </ExpenseFiltersContext.Provider>
+  );
+}
+
+export function useExpenseFilters() {
+  const context = useContext(ExpenseFiltersContext);
+  if (!context) {
+    throw new Error(
+      "useExpenseFilters must be used within an ExpenseFiltersProvider"
+    );
+  }
+  return context;
+}
+

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { Filter } from "lucide-react";
 import { AddExpenseModal } from "@/components/add-expense-modal";
 import { Button } from "@/components/ui/button";
@@ -6,8 +7,11 @@ import { StatsCards } from "@/components/stats-cards";
 import { ExpenseChart } from "@/components/expense-chart";
 import { CategoryBreakdown } from "@/components/category-breakdown";
 import { RecentExpenses } from "@/components/recent-expenses";
+import { ExpenseFiltersSheet } from "@/components/expense-filters";
+import { ActiveExpenseFilters } from "@/components/active-expense-filters";
 
 export default function Dashboard() {
+  const [isFilterSheetOpen, setIsFilterSheetOpen] = useState(false);
   const currentDate = new Date().toLocaleDateString("en-US", {
     weekday: "long",
     year: "numeric",
@@ -44,10 +48,15 @@ export default function Dashboard() {
               variant="outline"
               className="gap-2 rounded-full border-white/50 bg-white/70 px-5 text-foreground shadow-sm backdrop-blur hover:bg-white/90 dark:border-white/10 dark:bg-slate-900/60 dark:hover:bg-slate-900/70"
               data-testid="button-filter"
+              onClick={() => setIsFilterSheetOpen(true)}
             >
               <Filter className="h-4 w-4" />
               Filter
             </Button>
+            <ExpenseFiltersSheet
+              open={isFilterSheetOpen}
+              onOpenChange={setIsFilterSheetOpen}
+            />
             <AddExpenseModal />
             <div className="md:hidden">
               <ThemeToggle />
@@ -55,6 +64,8 @@ export default function Dashboard() {
           </div>
         </div>
       </section>
+
+      <ActiveExpenseFilters />
 
       <StatsCards />
 


### PR DESCRIPTION
## Summary
- add an expense filters context provider to share category and date selections across views
- build a reusable sheet UI and active filter chips for adjusting and clearing filters
- apply the shared filters to the expenses list, dashboard filter controls, recent expenses, and the spending chart

## Testing
- npm run lint *(fails: ESLint configuration missing in repository)*
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9ec53742883218cf0e757581b3293