### PR TITLE
Improve sidebar, auth, and 404 styling

### DIFF
--- a/client/src/components/sidebar.tsx
+++ b/client/src/components/sidebar.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from "react";
 import { Link, useLocation } from "wouter";
 import { cn } from "@/lib/utils";
 import {
@@ -6,9 +5,6 @@ import {
   CreditCard,
   BarChart3,
   LogOut,
-  Settings,
-  Sparkles,
-  KeyIcon,
   SettingsIcon,
 } from "lucide-react";
 import { ThemeToggle } from "@/components/theme-toggle";
@@ -22,7 +18,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 const navigation = [
   { name: "Dashboard", href: "/", icon: LayoutDashboard },
   { name: "Expenses", href: "/expenses", icon: CreditCard },
-  { name: "Analytics", href: "/analytics", icon: KeyIcon },
+  { name: "Analytics", href: "/analytics", icon: BarChart3 },
   { name: "Settings", href: "/settings", icon: SettingsIcon },
 ];
 
@@ -55,15 +51,15 @@ export function Sidebar() {
   });
 
   return (
-    <aside className="fixed left-0 top-0 z-50 flex h-full w-64 flex-col border-r border-border bg-white shadow-lg">
+    <aside className="fixed left-0 top-0 z-50 flex h-full w-64 flex-col border-r border-sidebar-border bg-sidebar text-sidebar-foreground shadow-[0_18px_45px_rgba(15,23,42,0.1)] backdrop-blur-xl">
       <div className="flex-1 p-6">
         <div className="mb-8 flex items-center space-x-3">
-          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-gradient-to-r from-purple-600 to-purple-700">
-            <BarChart3 className="h-6 w-6 text-white" />
+          <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-gradient-to-br from-sidebar-primary to-primary shadow-inner">
+            <BarChart3 className="h-5 w-5 text-sidebar-primary-foreground" />
           </div>
-          <div>
-            <h1 className="text-xl font-bold">DollarTrack</h1>
-            <p className="text-sm text-muted-foreground">Smart Finance</p>
+          <div className="leading-tight">
+            <h1 className="text-lg font-semibold tracking-tight">DollarTrack</h1>
+            <p className="text-xs uppercase tracking-[0.35em] text-sidebar-foreground/70">Smart Finance</p>
           </div>
         </div>
 
@@ -80,7 +76,7 @@ export function Sidebar() {
                     "group flex items-center space-x-3 rounded-2xl px-4 py-3 text-sm font-medium transition-all",
                     isActive
                       ? "bg-gradient-to-r from-primary to-purple-500 text-primary-foreground shadow-lg shadow-primary/20"
-                      : "text-muted-foreground hover:bg-secondary/80 hover:text-foreground"
+                      : "text-sidebar-foreground/70 hover:bg-sidebar-accent hover:text-sidebar-foreground"
                   )}
                 >
                   <Icon className="h-5 w-5" />
@@ -115,7 +111,7 @@ export function Sidebar() {
       </div>
 
       {user ? (
-        <div className="border-t border-border p-6">
+        <div className="border-t border-sidebar-border p-6">
           <div className="mb-3">
             <p className="text-sm font-semibold text-foreground">{user.name}</p>
             <p className="text-xs text-muted-foreground">{user.email}</p>

--- a/client/src/pages/login.tsx
+++ b/client/src/pages/login.tsx
@@ -73,15 +73,19 @@ export default function Login() {
   };
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-slate-50 to-slate-100 px-4 py-16">
-      <Card className="w-full max-w-md shadow-xl">
-        <CardHeader className="space-y-1">
-          <CardTitle className="text-2xl font-bold">Welcome back</CardTitle>
-          <CardDescription>
-            Sign in to access your finance dashboard.
+    <div className="relative flex min-h-screen items-center justify-center overflow-hidden bg-gradient-to-br from-slate-50 via-slate-100 to-purple-100 px-4 py-16 text-foreground transition-colors dark:from-slate-950 dark:via-slate-900 dark:to-indigo-950">
+      <span className="pointer-events-none absolute -left-40 top-10 h-72 w-72 rounded-full bg-primary/20 blur-3xl dark:bg-primary/25" />
+      <span className="pointer-events-none absolute -right-32 bottom-10 h-72 w-72 rounded-full bg-indigo-300/20 blur-3xl dark:bg-indigo-500/20" />
+      <Card className="relative z-10 w-full max-w-md overflow-hidden border border-white/50 bg-gradient-to-br from-white/95 via-white/80 to-white/70 shadow-2xl shadow-primary/20 backdrop-blur-2xl dark:border-white/10 dark:from-slate-900/95 dark:via-slate-900/80 dark:to-slate-900/70">
+        <span className="pointer-events-none absolute inset-x-10 -top-16 h-32 rounded-full bg-primary/15 blur-3xl dark:bg-primary/25" />
+        <span className="pointer-events-none absolute inset-x-12 bottom-0 h-32 rounded-full bg-indigo-200/20 blur-3xl dark:bg-indigo-500/20" />
+        <CardHeader className="relative z-10 space-y-1 text-center">
+          <CardTitle className="text-2xl font-semibold">Welcome back</CardTitle>
+          <CardDescription className="text-sm text-muted-foreground">
+            Sign in to access your finance dashboard and stay on top of every transaction.
           </CardDescription>
         </CardHeader>
-        <CardContent>
+        <CardContent className="relative z-10">
           <form
             className="space-y-4"
             onSubmit={form.handleSubmit(onSubmit)}
@@ -146,16 +150,18 @@ export default function Login() {
 
             <Button
               type="submit"
-              className="w-full"
+              className="w-full rounded-full"
               disabled={mutation.isLoading}
             >
               {mutation.isLoading ? "Signing in..." : "Sign in"}
             </Button>
           </form>
         </CardContent>
-        <CardFooter className="flex flex-col items-start gap-4 text-sm text-muted-foreground">
-          <div className="flex w-full items-center justify-between gap-2">
-            <span>New to DollarTrack?</span>
+        <CardFooter className="relative z-10 flex flex-col items-start gap-4 text-sm text-muted-foreground">
+          <div className="flex w-full items-center justify-between gap-2 text-left">
+            <span className="text-xs uppercase tracking-[0.3em] text-muted-foreground/80">
+              New to DollarTrack?
+            </span>
             <Link href="/register">
               <a className="font-medium text-primary hover:underline">
                 Create an account

--- a/client/src/pages/not-found.tsx
+++ b/client/src/pages/not-found.tsx
@@ -1,20 +1,52 @@
-import { Card, CardContent } from "@/components/ui/card";
-import { AlertCircle } from "lucide-react";
+import { Link } from "wouter";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { AlertCircle, ArrowRight } from "lucide-react";
 
 export default function NotFound() {
   return (
-    <div className="min-h-screen w-full flex items-center justify-center bg-gray-50">
-      <Card className="w-full max-w-md mx-4">
-        <CardContent className="pt-6">
-          <div className="flex mb-4 gap-2">
-            <AlertCircle className="h-8 w-8 text-red-500" />
-            <h1 className="text-2xl font-bold text-gray-900">404 Page Not Found</h1>
+    <div className="relative flex min-h-screen items-center justify-center overflow-hidden bg-gradient-to-br from-slate-50 via-slate-100 to-purple-100 px-6 py-16 text-foreground transition-colors dark:from-slate-950 dark:via-slate-900 dark:to-indigo-950">
+      <span className="pointer-events-none absolute -left-44 top-12 h-80 w-80 rounded-full bg-primary/20 blur-3xl dark:bg-primary/25" />
+      <span className="pointer-events-none absolute right-[-8rem] bottom-16 h-80 w-80 rounded-full bg-indigo-300/20 blur-3xl dark:bg-indigo-500/25" />
+      <Card className="relative z-10 w-full max-w-lg overflow-hidden border border-white/50 bg-gradient-to-br from-white/95 via-white/80 to-white/70 shadow-2xl shadow-primary/20 backdrop-blur-2xl dark:border-white/10 dark:from-slate-900/95 dark:via-slate-900/80 dark:to-slate-900/70">
+        <span className="pointer-events-none absolute inset-x-14 -top-20 h-36 rounded-full bg-primary/15 blur-3xl dark:bg-primary/25" />
+        <span className="pointer-events-none absolute inset-x-16 bottom-0 h-36 rounded-full bg-purple-200/20 blur-3xl dark:bg-purple-500/25" />
+        <CardHeader className="relative z-10 space-y-4 text-center">
+          <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-primary/15 text-primary">
+            <AlertCircle className="h-6 w-6" />
           </div>
-
-          <p className="mt-4 text-sm text-gray-600">
-            Did you forget to add the page to the router?
+          <CardTitle className="text-3xl font-semibold">Page not found</CardTitle>
+          <CardDescription>
+            The page you&apos;re looking for doesn&apos;t exist or may have moved. Let&apos;s get you back to where things make sense.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="relative z-10 space-y-4 text-sm text-muted-foreground">
+          <p>
+            Double-check the URL, explore the navigation menu, or return to your dashboard to continue managing your finances.
+          </p>
+          <p>
+            Need a hand? Reach out to <a className="font-medium text-primary hover:underline" href="mailto:hello@dollartrack.app">hello@dollartrack.app</a> and we&apos;ll help you find what you need.
           </p>
         </CardContent>
+        <CardFooter className="relative z-10 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-center">
+          <Link href="/">
+            <a className="inline-flex w-full items-center justify-center gap-2 rounded-full bg-gradient-to-r from-primary via-purple-500 to-indigo-500 px-6 py-3 text-sm font-medium text-primary-foreground shadow-lg shadow-primary/30 transition hover:brightness-105 hover:shadow-xl sm:w-auto">
+              Back to safety
+              <ArrowRight className="h-4 w-4" />
+            </a>
+          </Link>
+          <Link href="/login">
+            <a className="inline-flex w-full items-center justify-center gap-2 rounded-full border border-white/60 bg-white/70 px-6 py-3 text-sm font-medium text-muted-foreground backdrop-blur transition hover:border-primary/40 hover:text-primary dark:border-white/15 dark:bg-slate-900/60 dark:hover:text-primary sm:w-auto">
+              Go to sign in
+            </a>
+          </Link>
+        </CardFooter>
       </Card>
     </div>
   );

--- a/client/src/pages/register.tsx
+++ b/client/src/pages/register.tsx
@@ -94,17 +94,21 @@ export default function Register() {
   };
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-slate-50 to-slate-100 px-4 py-16">
-      <Card className="w-full max-w-lg shadow-xl">
-        <CardHeader className="space-y-1">
-          <CardTitle className="text-2xl font-bold">
+    <div className="relative flex min-h-screen items-center justify-center overflow-hidden bg-gradient-to-br from-slate-50 via-slate-100 to-purple-100 px-4 py-16 text-foreground transition-colors dark:from-slate-950 dark:via-slate-900 dark:to-indigo-950">
+      <span className="pointer-events-none absolute -left-40 top-16 h-72 w-72 rounded-full bg-primary/20 blur-3xl dark:bg-primary/25" />
+      <span className="pointer-events-none absolute right-[-6rem] bottom-12 h-80 w-80 rounded-full bg-purple-300/20 blur-3xl dark:bg-purple-500/20" />
+      <Card className="relative z-10 w-full max-w-lg overflow-hidden border border-white/50 bg-gradient-to-br from-white/95 via-white/80 to-white/70 shadow-2xl shadow-primary/20 backdrop-blur-2xl dark:border-white/10 dark:from-slate-900/95 dark:via-slate-900/80 dark:to-slate-900/70">
+        <span className="pointer-events-none absolute inset-x-14 -top-20 h-36 rounded-full bg-primary/15 blur-3xl dark:bg-primary/25" />
+        <span className="pointer-events-none absolute inset-x-16 bottom-0 h-36 rounded-full bg-purple-200/20 blur-3xl dark:bg-purple-500/20" />
+        <CardHeader className="relative z-10 space-y-2 text-center">
+          <CardTitle className="text-2xl font-semibold">
             Create your account
           </CardTitle>
-          <CardDescription>
+          <CardDescription className="text-sm text-muted-foreground">
             Get started with smarter money tracking in minutes.
           </CardDescription>
         </CardHeader>
-        <CardContent>
+        <CardContent className="relative z-10">
           <form
             className="space-y-4"
             onSubmit={form.handleSubmit(onSubmit)}
@@ -222,16 +226,18 @@ export default function Register() {
 
             <Button
               type="submit"
-              className="w-full"
+              className="w-full rounded-full"
               disabled={mutation.isLoading}
             >
               {mutation.isLoading ? "Creating account..." : "Create account"}
             </Button>
           </form>
         </CardContent>
-        <CardFooter className="flex flex-col items-start gap-4 text-sm text-muted-foreground">
+        <CardFooter className="relative z-10 flex flex-col items-start gap-4 text-sm text-muted-foreground">
           <div className="flex w-full items-center justify-between gap-2">
-            <span>Already have an account?</span>
+            <span className="text-xs uppercase tracking-[0.3em] text-muted-foreground/80">
+              Already have an account?
+            </span>
             <Link href="/login">
               <a className="font-medium text-primary hover:underline">
                 Sign in


### PR DESCRIPTION
## Summary
- align the sidebar shell with the theme palette and adjust the analytics icon
- refresh the login and registration views with glassmorphism styling and dark-mode friendly backgrounds
- redesign the not-found screen with branded gradients and helpful navigation actions

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca0c0bb08c8321bea7bab9bf93a30a