### PR TITLE
Connect analytics page to Supabase data

### DIFF
--- a/client/src/pages/analytics.tsx
+++ b/client/src/pages/analytics.tsx
@@ -31,6 +31,7 @@ import {
   Activity,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { fetchCategoryBreakdown, fetchExpenses, fetchExpensesSummary, type ExpensesSummary } from "@/lib/api";
 import { type ExpenseWithCategory } from "@shared/schema";
 
 type CategoryBreakdownItem = {
@@ -54,24 +55,23 @@ const formatCurrency = (amount: number) =>
   }).format(amount ?? 0);
 
 export default function Analytics() {
-  const { data: summary, isLoading: isSummaryLoading } = useQuery<{
-    total: number;
-    monthly: number;
-    weekly: number;
-  }>({
-    queryKey: ["/api/analytics/summary"],
+  const { data: summary, isLoading: isSummaryLoading } = useQuery<ExpensesSummary>({
+    queryKey: ["expenses", "summary"],
+    queryFn: fetchExpensesSummary,
   });
 
   const { data: expenses, isLoading: isExpensesLoading } = useQuery<
     ExpenseWithCategory[]
   >({
-    queryKey: ["/api/expenses"],
+    queryKey: ["expenses", "list"],
+    queryFn: fetchExpenses,
   });
 
   const { data: categoryBreakdown, isLoading: isBreakdownLoading } = useQuery<
     CategoryBreakdownItem[]
   >({
-    queryKey: ["/api/analytics/categories"],
+    queryKey: ["expenses", "categories"],
+    queryFn: fetchCategoryBreakdown,
   });
 
   const isLoading = isSummaryLoading || isExpensesLoading || isBreakdownLoading;


### PR DESCRIPTION
## Summary
- load analytics summary, expenses, and category breakdown data through the Supabase-powered API helpers
- update React Query keys and functions so the analytics dashboard reflects live database data

## Testing
- npm run lint *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68ca670ae1248321bbca3ab1e2fdb0b4