### PR TITLE
Add collapsible sidebar and card animations

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -11,6 +11,11 @@ import { useEffect } from "react";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { Toaster } from "@/components/ui/toaster";
 import { Sidebar } from "@/components/sidebar";
+import {
+  SidebarInset,
+  SidebarProvider,
+  SidebarTrigger,
+} from "@/components/ui/sidebar";
 import { queryClient } from "./lib/queryClient";
 
 import Dashboard from "@/pages/dashboard";
@@ -27,6 +32,7 @@ import { useCurrentUser } from "@/hooks/use-current-user";
 import { ExpenseFiltersProvider } from "@/hooks/use-expense-filters";
 import { ArrowRight } from "lucide-react";
 import { Button } from "./components/ui/button";
+import { ThemeToggle } from "./components/theme-toggle";
 
 /* ----------------- UI ----------------- */
 function LoadingScreen() {
@@ -76,19 +82,25 @@ function RedirectIfAuthed({ children }) {
 function ProtectedLayout() {
   // Shell for /app/*
   return (
-    <div className="relative min-h-screen overflow-hidden bg-transparent text-foreground transition-colors duration-500">
-      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(129,140,248,0.16),_transparent_62%),radial-gradient(circle_at_bottom,_rgba(236,72,153,0.08),_transparent_60%)] dark:bg-[radial-gradient(circle_at_top,_rgba(79,70,229,0.35),_transparent_60%),radial-gradient(circle_at_bottom,_rgba(15,23,42,0.75),_transparent_70%)]" />
-      <div className="pointer-events-none absolute -left-36 top-24 h-[22rem] w-[22rem] rounded-full bg-primary/10 blur-3xl dark:bg-primary/25" />
-      <div className="pointer-events-none absolute right-[-18%] top-36 h-[26rem] w-[26rem] rounded-full bg-purple-200/40 blur-3xl dark:bg-purple-500/20" />
-      <div className="pointer-events-none absolute left-1/2 top-[70%] h-96 w-[36rem] -translate-x-1/2 rounded-[10rem] bg-gradient-to-r from-sky-200/30 via-primary/15 to-purple-200/30 blur-3xl dark:from-sky-500/20 dark:via-primary/20 dark:to-purple-500/25" />
-
+    <SidebarProvider>
       <Sidebar />
-      <main className="relative z-10 ml-0 flex min-h-screen flex-col px-6 pb-16 pt-5 transition-[margin] md:ml-72 md:px-10 lg:px-16">
-        <div className="mx-auto w-full max-w-7xl">
-          <Outlet />
+      <SidebarInset className="relative flex min-h-screen flex-1 overflow-hidden bg-transparent text-foreground transition-colors duration-500">
+        <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(129,140,248,0.16),_transparent_62%),radial-gradient(circle_at_bottom,_rgba(236,72,153,0.08),_transparent_60%)] dark:bg-[radial-gradient(circle_at_top,_rgba(79,70,229,0.35),_transparent_60%),radial-gradient(circle_at_bottom,_rgba(15,23,42,0.75),_transparent_70%)]" />
+        <div className="pointer-events-none absolute -left-36 top-24 h-[22rem] w-[22rem] rounded-full bg-primary/10 blur-3xl dark:bg-primary/25" />
+        <div className="pointer-events-none absolute right-[-18%] top-36 h-[26rem] w-[26rem] rounded-full bg-purple-200/40 blur-3xl dark:bg-purple-500/20" />
+        <div className="pointer-events-none absolute left-1/2 top-[70%] h-96 w-[36rem] -translate-x-1/2 rounded-[10rem] bg-gradient-to-r from-sky-200/30 via-primary/15 to-purple-200/30 blur-3xl dark:from-sky-500/20 dark:via-primary/20 dark:to-purple-500/25" />
+
+        <div className="relative z-10 flex min-h-screen w-full flex-col px-6 pb-16 pt-5 transition-[padding] md:px-10 lg:px-16">
+          <div className="flex items-center justify-between pb-6 md:hidden">
+            <SidebarTrigger className="h-11 w-11 rounded-2xl border border-white/60 bg-white/85 text-foreground shadow-sm hover:bg-white/95 dark:border-white/10 dark:bg-slate-900/70 dark:hover:bg-slate-900/60" />
+            <ThemeToggle className="h-11 w-11 border-white/70 bg-white/80 text-foreground shadow-none hover:bg-white/90 dark:border-white/20 dark:bg-slate-900/70 dark:hover:bg-slate-900/60" />
+          </div>
+          <div className="mx-auto w-full max-w-7xl flex-1">
+            <Outlet />
+          </div>
         </div>
-      </main>
-    </div>
+      </SidebarInset>
+    </SidebarProvider>
   );
 }
 

--- a/client/src/components/sidebar.tsx
+++ b/client/src/components/sidebar.tsx
@@ -1,22 +1,37 @@
-﻿import { Link, useLocation, useNavigate } from "react-router-dom";
-import { cn } from "@/lib/utils";
+import {
+  Link,
+  useLocation,
+  useNavigate,
+} from "react-router-dom";
 import {
   LayoutDashboard,
   CreditCard,
   LineChart,
   LogOut,
   Settings,
-  Sparkles,
-  BarChart3,
   AlbumIcon,
+  ChevronLeft,
+  ChevronRight,
 } from "lucide-react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import {
+  Sidebar as SidebarPrimitive,
+  SidebarRail,
+  useSidebar,
+} from "@/components/ui/sidebar";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { useToast } from "@/hooks/use-toast";
-import { extractErrorMessage } from "@/lib/errors";
-import { supabase } from "@/lib/supabase";
 import { useCurrentUser, currentUserQueryKey } from "@/hooks/use-current-user";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { supabase } from "@/lib/supabase";
+import { extractErrorMessage } from "@/lib/errors";
+import { cn } from "@/lib/utils";
 
 const navigation = [
   { name: "Dashboard", href: "/", icon: LayoutDashboard },
@@ -32,6 +47,9 @@ export function Sidebar() {
   const { data: user } = useCurrentUser();
   const queryClient = useQueryClient();
   const { toast } = useToast();
+  const { state, toggleSidebar, isMobile, setOpenMobile } = useSidebar();
+
+  const isCollapsed = state === "collapsed";
 
   const logoutMutation = useMutation({
     mutationFn: async () => {
@@ -58,89 +76,176 @@ export function Sidebar() {
   const userInitial = user?.name?.[0] ?? user?.email?.[0] ?? "";
 
   return (
-    <aside className="fixed left-0 top-0 z-40 flex h-full w-72 flex-col border-r border-white/60 bg-white/85 shadow-2xl backdrop-blur-2xl transition-colors dark:border-white/10 dark:bg-slate-950/70">
+    <SidebarPrimitive
+      collapsible="icon"
+      className="relative z-40 hidden border-r border-white/60 bg-white/85 shadow-2xl backdrop-blur-2xl transition-colors dark:border-white/10 dark:bg-slate-950/70 md:flex"
+    >
+      {!isMobile && <SidebarRail />}
       <span className="pointer-events-none absolute inset-x-4 top-6 h-32 rounded-3xl bg-gradient-to-b from-primary/25 via-transparent to-transparent blur-3xl dark:from-primary/20" />
       <span className="pointer-events-none absolute inset-x-0 bottom-0 h-40 bg-gradient-to-t from-primary/10 via-transparent to-transparent blur-3xl dark:from-primary/20" />
-      <div className="relative flex h-full flex-col px-6 pb-6 pt-8">
-        <div className="flex items-start justify-between gap-4">
-          <div className="flex items-center gap-3">
-            <div>
-              <h1 className="text-lg font-semibold text-foreground">
-                DollarTrack
-              </h1>
-              <p className="text-xs uppercase tracking-[0.28em] text-muted-foreground">
-                Smart finance
-              </p>
+
+      <div className="relative flex h-full flex-col px-4 pb-6 pt-8">
+        <div
+          className={cn(
+            "flex items-start justify-between gap-4",
+            isCollapsed && "flex-col items-center gap-6"
+          )}
+        >
+          <div
+            className={cn(
+              "flex items-center gap-3",
+              isCollapsed && "flex-col items-center gap-2"
+            )}
+          >
+            <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-primary/15 text-sm font-semibold uppercase tracking-[0.28em] text-primary shadow-sm">
+              DT
             </div>
+            {!isCollapsed && (
+              <div>
+                <h1 className="text-lg font-semibold text-foreground">DollarTrack</h1>
+                <p className="text-xs uppercase tracking-[0.28em] text-muted-foreground">
+                  Smart finance
+                </p>
+              </div>
+            )}
           </div>
-          <div className="hidden md:block">
-            <ThemeToggle className="h-11 w-11 border-white/70 bg-white/80 text-foreground shadow-none hover:bg-white/90 dark:border-white/20 dark:bg-slate-900/70 dark:hover:bg-slate-900/60" />
+          <div
+            className={cn(
+              "hidden items-center gap-2 md:flex",
+              isCollapsed && "flex-col"
+            )}
+          >
+            <button
+              type="button"
+              onClick={toggleSidebar}
+              aria-label={isCollapsed ? "Expand sidebar" : "Collapse sidebar"}
+              className="flex h-11 w-11 items-center justify-center rounded-2xl border border-white/60 bg-white/80 text-foreground shadow-none transition hover:bg-white/90 dark:border-white/20 dark:bg-slate-900/70 dark:hover:bg-slate-900/60"
+            >
+              {isCollapsed ? (
+                <ChevronRight className="h-4 w-4" />
+              ) : (
+                <ChevronLeft className="h-4 w-4" />
+              )}
+            </button>
+            <ThemeToggle
+              className={cn(
+                "h-11 w-11 border-white/70 bg-white/80 text-foreground shadow-none hover:bg-white/90 dark:border-white/20 dark:bg-slate-900/70 dark:hover:bg-slate-900/60",
+                isCollapsed && "mt-2"
+              )}
+            />
           </div>
         </div>
 
-        <nav className="mt-10 flex flex-col gap-2">
+        <nav
+          className={cn(
+            "mt-10 flex flex-1 flex-col gap-2 overflow-y-auto",
+            isCollapsed && "mt-8 items-center gap-3"
+          )}
+        >
           {navigation.map((item) => {
             const isActive =
-              (location.pathname == "/app" && item.href == "/") ||
-              location.pathname == "/app" + item.href;
+              (location.pathname === "/app" && item.href === "/") ||
+              location.pathname === "/app" + item.href;
             const Icon = item.icon;
 
             return (
-              <Link key={item.name} to={"/app" + item.href}>
-                <a
-                  data-testid={`nav-link-${item.name.toLowerCase()}`}
-                  aria-current={isActive ? "page" : undefined}
-                  className={cn(
-                    "group flex items-center gap-3 rounded-2xl px-4 py-3 text-sm font-medium transition-all",
-                    isActive
-                      ? "bg-gradient-to-r from-primary via-primary/80 to-primary/60 text-white shadow-lg shadow-primary/30"
-                      : "text-muted-foreground hover:bg-white/70 hover:text-foreground dark:hover:bg-white/10"
-                  )}
-                >
-                  <span
+              <Tooltip key={item.name}>
+                <TooltipTrigger asChild>
+                  <Link
+                    to={"/app" + item.href}
+                    data-testid={`nav-link-${item.name.toLowerCase()}`}
+                    aria-current={isActive ? "page" : undefined}
+                    aria-label={isCollapsed ? item.name : undefined}
+                    title={isCollapsed ? item.name : undefined}
+                    onClick={() => {
+                      if (isMobile) {
+                        setOpenMobile(false);
+                      }
+                    }}
                     className={cn(
-                      "flex h-10 w-10 items-center justify-center rounded-xl border border-white/60 bg-white/80 text-primary shadow-sm backdrop-blur dark:border-white/10 dark:bg-slate-900/70",
-                      isActive &&
-                        "border-transparent bg-white/20 text-white shadow-none dark:bg-white/10"
+                      "group/nav relative flex w-full items-center gap-3 rounded-2xl px-4 py-3 text-sm font-medium transition-all",
+                      isActive
+                        ? "bg-gradient-to-r from-primary via-primary/80 to-primary/60 text-white shadow-lg shadow-primary/30"
+                        : "text-muted-foreground hover:bg-white/70 hover:text-foreground dark:hover:bg-white/10",
+                      isCollapsed &&
+                        "justify-center px-0 text-foreground/80 hover:text-foreground"
                     )}
                   >
-                    <Icon className="h-5 w-5" />
-                  </span>
-                  <span>{item.name}</span>
-                  {isActive ? (
-                    <span className="ml-auto h-2 w-2 rounded-full bg-white/80 shadow" />
-                  ) : null}
-                </a>
-              </Link>
+                    <span
+                      className={cn(
+                        "flex h-10 w-10 items-center justify-center rounded-xl border border-white/60 bg-white/80 text-primary shadow-sm backdrop-blur transition-colors dark:border-white/10 dark:bg-slate-900/70",
+                        isActive &&
+                          "border-transparent bg-white/20 text-white shadow-none dark:bg-white/10",
+                        isCollapsed && "h-11 w-11"
+                      )}
+                    >
+                      <Icon className="h-5 w-5" />
+                    </span>
+                    {!isCollapsed && <span>{item.name}</span>}
+                    {isActive && !isCollapsed ? (
+                      <span className="ml-auto h-2 w-2 rounded-full bg-white/80 shadow" />
+                    ) : null}
+                  </Link>
+                </TooltipTrigger>
+                <TooltipContent
+                  side="right"
+                  align="center"
+                  hidden={!isCollapsed}
+                >
+                  {item.name}
+                </TooltipContent>
+              </Tooltip>
             );
           })}
         </nav>
 
         {user ? (
-          <div className="mt-auto rounded-3xl border border-white/60 bg-white/85 p-5 shadow-lg backdrop-blur dark:border-white/10 dark:bg-slate-900/70">
-            <div className="flex items-center gap-3">
+          <div
+            className={cn(
+              "mt-6 rounded-3xl border border-white/60 bg-white/85 p-5 shadow-lg backdrop-blur transition-colors dark:border-white/10 dark:bg-slate-900/70",
+              isCollapsed && "flex flex-col items-center gap-3 p-4"
+            )}
+          >
+            <div
+              className={cn(
+                "flex items-center gap-3",
+                isCollapsed && "flex-col gap-2 text-center"
+              )}
+            >
               <div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/15 text-primary">
                 {userInitial.toUpperCase()}
               </div>
-              <div>
-                <p className="text-sm font-semibold text-foreground">
-                  {user.name}
-                </p>
-                <p className="text-xs text-muted-foreground">{user.email}</p>
-              </div>
+              {!isCollapsed && (
+                <div>
+                  <p className="text-sm font-semibold text-foreground">{user.name}</p>
+                  <p className="text-xs text-muted-foreground">{user.email}</p>
+                </div>
+              )}
             </div>
-            <Button
-              variant="outline"
-              size="sm"
-              className="mt-4 w-full justify-center gap-2 rounded-full border-white/60 bg-white/80 text-foreground shadow-sm hover:bg-white/90 dark:border-white/10 dark:bg-slate-900/60 dark:hover:bg-slate-900/70"
-              onClick={() => logoutMutation.mutate()}
-            >
-              <LogOut className="h-4 w-4" />
-              Logout
-            </Button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="outline"
+                  size={isCollapsed ? "icon" : "sm"}
+                  aria-label="Logout"
+                  className={cn(
+                    "mt-4 w-full justify-center gap-2 rounded-full border-white/60 bg-white/80 text-foreground shadow-sm transition-colors hover:bg-white/90 dark:border-white/10 dark:bg-slate-900/60 dark:hover:bg-slate-900/70",
+                    isCollapsed &&
+                      "h-11 w-11 rounded-2xl border-white/40 bg-white/75 p-0"
+                  )}
+                  onClick={() => logoutMutation.mutate()}
+                >
+                  <LogOut className="h-4 w-4" />
+                  {!isCollapsed && "Logout"}
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="right" hidden={!isCollapsed}>
+                Logout
+              </TooltipContent>
+            </Tooltip>
           </div>
         ) : null}
       </div>
-    </aside>
+    </SidebarPrimitive>
   );
 }

--- a/client/src/components/ui/card.tsx
+++ b/client/src/components/ui/card.tsx
@@ -1,20 +1,44 @@
 import * as React from "react";
+import { HTMLMotionProps, motion } from "framer-motion";
 
 import { cn } from "@/lib/utils";
 
-const Card = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
-  <div
-    ref={ref}
-    className={cn(
-      "rounded-3xl border border-white/40 bg-card text-card-foreground shadow-lg shadow-black/5 transition-colors supports-[backdrop-filter:blur(0px)]:backdrop-blur-xl dark:border-white/10",
-      className
-    )}
-    {...props}
-  />
-));
+type CardProps = HTMLMotionProps<"div"> & {
+  disableAnimation?: boolean;
+};
+
+const Card = React.forwardRef<HTMLDivElement, CardProps>(
+  (
+    {
+      className,
+      disableAnimation = false,
+      initial,
+      animate,
+      exit,
+      transition,
+      ...props
+    },
+    ref
+  ) => (
+    <motion.div
+      ref={ref}
+      layout
+      initial={disableAnimation ? false : initial ?? { opacity: 0, y: 20, scale: 0.98 }}
+      animate={disableAnimation ? animate : animate ?? { opacity: 1, y: 0, scale: 1 }}
+      exit={disableAnimation ? exit : exit ?? { opacity: 0, y: -12, scale: 0.98 }}
+      transition={
+        disableAnimation
+          ? transition
+          : transition ?? { duration: 0.45, ease: [0.16, 1, 0.3, 1] }
+      }
+      className={cn(
+        "will-change-auto rounded-3xl border border-white/40 bg-card text-card-foreground shadow-lg shadow-black/5 transition-colors supports-[backdrop-filter:blur(0px)]:backdrop-blur-xl dark:border-white/10",
+        className
+      )}
+      {...props}
+    />
+  )
+);
 Card.displayName = "Card";
 
 const CardHeader = React.forwardRef<


### PR DESCRIPTION
## Summary
- wrap the protected layout with the shared sidebar provider and add a mobile trigger row
- rebuild the sidebar component to support icon-only collapse, mobile sheet closing, and tooltips
- animate the shared card component with framer-motion so cards fade and lift into place on mount

## Testing
- npm run build *(fails: Rollup cannot resolve "react-router-dom" because the package is missing from node_modules in this environment)*
- npm run lint *(fails: ESLint v9 requires an eslint.config.js file in this repository)*

------
https://chatgpt.com/codex/tasks/task_e_68cabc970ffc8321bd7a63e7c1e5e803