### PR TITLE
Add modern modal component and apply across dialogs

### DIFF
--- a/client/src/components/add-expense-modal.tsx
+++ b/client/src/components/add-expense-modal.tsx
@@ -3,12 +3,13 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from "@/components/ui/dialog";
+  Modal,
+  ModalContent,
+  ModalHeader,
+  ModalTitle,
+  ModalTrigger,
+  ModalFooter,
+} from "@/components/ui/modal";
 import {
   Form,
   FormControl,
@@ -84,21 +85,19 @@ export function AddExpenseModal({ children }: AddExpenseModalProps) {
   };
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger asChild>
+    <Modal open={open} onOpenChange={setOpen}>
+      <ModalTrigger asChild>
         {children || (
           <Button className="gap-2" data-testid="button-add-expense">
             <Plus className="h-5 w-5" />
             <span>Add Expense</span>
           </Button>
         )}
-      </DialogTrigger>
-      <DialogContent className="sm:max-w-lg rounded-3xl border border-white/40 bg-gradient-to-br from-white/95 to-white/80 p-8 shadow-xl backdrop-blur-2xl dark:border-white/10 dark:from-slate-900/95 dark:to-slate-900/80">
-        <DialogHeader>
-          <DialogTitle className="text-2xl font-semibold">
-            Add New Expense
-          </DialogTitle>
-        </DialogHeader>
+      </ModalTrigger>
+      <ModalContent>
+        <ModalHeader>
+          <ModalTitle>Add New Expense</ModalTitle>
+        </ModalHeader>
 
         <Form {...form}>
           <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
@@ -201,12 +200,11 @@ export function AddExpenseModal({ children }: AddExpenseModalProps) {
                 </FormItem>
               )}
             />
-
-            <div className="flex gap-4 pt-4">
+            <ModalFooter className="mt-8 gap-4">
               <Button
                 type="button"
                 variant="outline"
-                className="flex-1"
+                className="w-full sm:w-auto"
                 onClick={() => setOpen(false)}
                 data-testid="button-cancel"
               >
@@ -215,15 +213,15 @@ export function AddExpenseModal({ children }: AddExpenseModalProps) {
               <Button
                 type="submit"
                 disabled={addExpenseMutation.isPending}
-                className="flex-1"
+                className="w-full sm:w-auto"
                 data-testid="button-submit-expense"
               >
                 {addExpenseMutation.isPending ? "Adding..." : "Add Expense"}
               </Button>
-            </div>
+            </ModalFooter>
           </form>
         </Form>
-      </DialogContent>
-    </Dialog>
+      </ModalContent>
+    </Modal>
   );
 }

--- a/client/src/components/edit-expense-modal.tsx
+++ b/client/src/components/edit-expense-modal.tsx
@@ -3,12 +3,13 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from "@/components/ui/dialog";
+  Modal,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalTitle,
+  ModalTrigger,
+} from "@/components/ui/modal";
 import {
   Form,
   FormControl,
@@ -92,12 +93,12 @@ export function EditExpenseModal({ expense, children }: EditExpenseModalProps) {
   };
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger asChild>{children}</DialogTrigger>
-      <DialogContent className="sm:max-w-lg rounded-3xl border border-white/40 bg-gradient-to-br from-white/95 to-white/80 p-8 shadow-xl backdrop-blur-2xl dark:border-white/10 dark:from-slate-900/95 dark:to-slate-900/80">
-        <DialogHeader>
-          <DialogTitle className="text-2xl font-semibold">Edit Expense</DialogTitle>
-        </DialogHeader>
+    <Modal open={open} onOpenChange={setOpen}>
+      <ModalTrigger asChild>{children}</ModalTrigger>
+      <ModalContent>
+        <ModalHeader>
+          <ModalTitle>Edit Expense</ModalTitle>
+        </ModalHeader>
 
         <Form {...form}>
           <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
@@ -200,12 +201,11 @@ export function EditExpenseModal({ expense, children }: EditExpenseModalProps) {
                 </FormItem>
               )}
             />
-
-            <div className="flex gap-4 pt-4">
+            <ModalFooter className="mt-8 gap-4">
               <Button
                 type="button"
                 variant="outline"
-                className="flex-1"
+                className="w-full sm:w-auto"
                 onClick={() => setOpen(false)}
                 data-testid="button-cancel-edit"
               >
@@ -214,15 +214,15 @@ export function EditExpenseModal({ expense, children }: EditExpenseModalProps) {
               <Button
                 type="submit"
                 disabled={updateExpenseMutation.isPending}
-                className="flex-1"
+                className="w-full sm:w-auto"
                 data-testid="button-submit-edit-expense"
               >
                 {updateExpenseMutation.isPending ? "Updating..." : "Update Expense"}
               </Button>
-            </div>
+            </ModalFooter>
           </form>
         </Form>
-      </DialogContent>
-    </Dialog>
+      </ModalContent>
+    </Modal>
   );
 }

--- a/client/src/components/ui/modal.tsx
+++ b/client/src/components/ui/modal.tsx
@@ -1,0 +1,117 @@
+import * as React from "react";
+import {
+  Dialog as DialogPrimitive,
+  DialogContent as DialogPrimitiveContent,
+  DialogTrigger as DialogPrimitiveTrigger,
+  DialogHeader as DialogPrimitiveHeader,
+  DialogTitle as DialogPrimitiveTitle,
+  DialogDescription as DialogPrimitiveDescription,
+  DialogFooter as DialogPrimitiveFooter,
+  DialogClose as DialogPrimitiveClose,
+  type DialogProps as DialogPrimitiveProps,
+} from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
+
+const baseContentClasses =
+  "group/modal sm:max-w-xl overflow-hidden rounded-3xl border border-white/40 bg-white/80 p-0 shadow-[0_30px_80px_rgba(15,23,42,0.18)] backdrop-blur-3xl dark:border-slate-800/60 dark:bg-slate-950/85";
+
+interface ModalContentProps
+  extends React.ComponentPropsWithoutRef<typeof DialogPrimitiveContent> {
+  containerClassName?: string;
+}
+
+const Modal = DialogPrimitive;
+const ModalTrigger = DialogPrimitiveTrigger;
+
+const ModalClose = DialogPrimitiveClose;
+
+const ModalContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitiveContent>,
+  ModalContentProps
+>(({ className, containerClassName, children, ...props }, ref) => (
+  <DialogPrimitiveContent
+    ref={ref}
+    className={cn(baseContentClasses, className)}
+    {...props}
+  >
+    <div className="relative overflow-hidden">
+      <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-primary/15 via-transparent to-primary/25 opacity-90 dark:from-primary/10 dark:via-transparent dark:to-primary/20" />
+      <div className={cn("relative px-8 py-7", containerClassName)}>{children}</div>
+    </div>
+  </DialogPrimitiveContent>
+));
+ModalContent.displayName = DialogPrimitiveContent.displayName;
+
+const ModalHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <DialogPrimitiveHeader
+    className={cn(
+      "space-y-2 text-left",
+      "[&>p]:text-base [&>p]:text-muted-foreground",
+      className
+    )}
+    {...props}
+  />
+);
+ModalHeader.displayName = "ModalHeader";
+
+const ModalTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitiveTitle>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitiveTitle>
+>(({ className, children, ...props }, ref) => (
+  <DialogPrimitiveTitle
+    ref={ref}
+    className={cn(
+      "text-3xl font-semibold tracking-tight text-foreground",
+      "drop-shadow-sm",
+      className
+    )}
+    {...props}
+  >
+    <span className="bg-gradient-to-r from-foreground via-foreground/90 to-foreground/70 bg-clip-text text-transparent">
+      {children}
+    </span>
+  </DialogPrimitiveTitle>
+));
+ModalTitle.displayName = DialogPrimitiveTitle.displayName;
+
+const ModalDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitiveDescription>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitiveDescription>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitiveDescription
+    ref={ref}
+    className={cn("text-sm leading-relaxed text-muted-foreground", className)}
+    {...props}
+  />
+));
+ModalDescription.displayName = DialogPrimitiveDescription.displayName;
+
+const ModalFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <DialogPrimitiveFooter
+    className={cn(
+      "mt-6 flex flex-col gap-3 sm:flex-row sm:justify-end",
+      className
+    )}
+    {...props}
+  />
+);
+ModalFooter.displayName = "ModalFooter";
+
+export type ModalProps = DialogPrimitiveProps;
+
+export {
+  Modal,
+  ModalTrigger,
+  ModalClose,
+  ModalContent,
+  ModalHeader,
+  ModalTitle,
+  ModalDescription,
+  ModalFooter,
+};

--- a/client/src/pages/categories.tsx
+++ b/client/src/pages/categories.tsx
@@ -8,13 +8,13 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
+  Modal,
+  ModalContent,
+  ModalDescription,
+  ModalFooter,
+  ModalHeader,
+  ModalTitle,
+} from "@/components/ui/modal";
 import {
   Form,
   FormControl,
@@ -30,16 +30,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
 import { useToast } from "@/hooks/use-toast";
 import { categoryIcons, getCategoryIcon } from "@/lib/categories";
 import {
@@ -112,16 +102,12 @@ function CategoryFormDialog({
   };
 
   return (
-    <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className="sm:max-w-lg rounded-3xl border border-white/40 bg-gradient-to-br from-white/95 to-white/80 p-8 shadow-xl backdrop-blur-2xl dark:border-white/10 dark:from-slate-900/95 dark:to-slate-900/80">
-        <DialogHeader>
-          <DialogTitle className="text-2xl font-semibold text-foreground">
-            {title}
-          </DialogTitle>
-          <DialogDescription className="text-sm text-muted-foreground">
-            {description}
-          </DialogDescription>
-        </DialogHeader>
+    <Modal open={open} onOpenChange={handleOpenChange}>
+      <ModalContent>
+        <ModalHeader>
+          <ModalTitle>{title}</ModalTitle>
+          <ModalDescription>{description}</ModalDescription>
+        </ModalHeader>
         <Form {...form}>
           <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
             <FormField
@@ -203,23 +189,28 @@ function CategoryFormDialog({
               )}
             />
 
-            <DialogFooter className="pt-2">
+            <ModalFooter className="gap-4">
               <Button
                 type="button"
                 variant="outline"
                 onClick={() => handleOpenChange(false)}
                 disabled={isSubmitting}
+                className="w-full sm:w-auto"
               >
                 Cancel
               </Button>
-              <Button type="submit" disabled={isSubmitting}>
+              <Button
+                type="submit"
+                disabled={isSubmitting}
+                className="w-full sm:w-auto"
+              >
                 {confirmLabel}
               </Button>
-            </DialogFooter>
+            </ModalFooter>
           </form>
         </Form>
-      </DialogContent>
-    </Dialog>
+      </ModalContent>
+    </Modal>
   );
 }
 
@@ -569,37 +560,43 @@ export default function Categories() {
         isSubmitting={updateCategoryMutation.isPending}
       />
 
-      <AlertDialog
+      <Modal
         open={Boolean(categoryToDelete)}
         onOpenChange={(open) => {
+          if (!open && deleteCategoryMutation.isPending) return;
           if (!open) setCategoryToDelete(null);
         }}
       >
-        <AlertDialogContent className="rounded-3xl border border-white/40 bg-gradient-to-br from-white/95 to-white/80 p-8 shadow-xl backdrop-blur-2xl dark:border-white/10 dark:from-slate-900/95 dark:to-slate-900/80">
-          <AlertDialogHeader>
-            <AlertDialogTitle className="text-2xl font-semibold text-foreground">
-              Delete category
-            </AlertDialogTitle>
-            <AlertDialogDescription className="text-sm text-muted-foreground">
+        <ModalContent>
+          <ModalHeader>
+            <ModalTitle>Delete category</ModalTitle>
+            <ModalDescription>
               {categoryToDelete
                 ? `This action will remove "${categoryToDelete.name}" from your category list. Expenses using this category will need to be reassigned.`
                 : "This action cannot be undone."}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={deleteCategoryMutation.isPending}>
+            </ModalDescription>
+          </ModalHeader>
+          <ModalFooter className="gap-4">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setCategoryToDelete(null)}
+              disabled={deleteCategoryMutation.isPending}
+              className="w-full sm:w-auto"
+            >
               Cancel
-            </AlertDialogCancel>
-            <AlertDialogAction
+            </Button>
+            <Button
+              type="button"
               onClick={handleDeleteCategory}
               disabled={deleteCategoryMutation.isPending}
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              className="w-full bg-destructive text-destructive-foreground hover:bg-destructive/90 sm:w-auto"
             >
               {deleteCategoryMutation.isPending ? "Deleting..." : "Delete"}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
     </PageLayout>
   );
 }


### PR DESCRIPTION
## Summary
- create a reusable modal wrapper with a refreshed gradient design and consistent spacing
- migrate the add and edit expense dialogs to the new modal component with modernized footers
- update category management dialogs, including delete confirmation, to reuse the modal styling

## Testing
- npm run lint *(fails: ESLint configuration missing in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68cae400a4c08321a3347244efdb8c26