### PR TITLE
feat: improve mobile layout and quick expense actions

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -14,6 +14,7 @@ import { Sidebar } from "@/components/sidebar";
 import { queryClient } from "./lib/queryClient";
 import { cn } from "@/lib/utils";
 import { ThemeToggle } from "@/components/theme-toggle";
+import { MobileNav } from "@/components/mobile-nav";
 
 import Dashboard from "@/pages/dashboard";
 import Expenses from "@/pages/expenses";
@@ -85,13 +86,15 @@ function ProtectedLayout() {
     <div className="relative min-h-screen bg-transparent text-foreground transition-colors">
       <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(129,140,248,0.12),_transparent_60%),radial-gradient(circle_at_bottom,_rgba(236,72,153,0.08),_transparent_65%)] dark:bg-[radial-gradient(circle_at_top,_rgba(79,70,229,0.28),_transparent_60%),radial-gradient(circle_at_bottom,_rgba(15,23,42,0.78),_transparent_70%)]" />
 
+      <MobileNav />
+
       <Sidebar
         collapsed={isSidebarCollapsed}
         onToggle={() => setIsSidebarCollapsed((previous) => !previous)}
       />
       <main
         className={cn(
-          "relative z-10 ml-0 flex min-h-screen flex-col px-4 pb-16 pt-5 transition-[margin] duration-200 sm:px-6 md:px-10 lg:px-16",
+          "relative z-10 ml-0 flex min-h-screen flex-col px-4 pb-24 pt-24 transition-[margin] duration-200 sm:px-6 md:px-10 md:pb-16 md:pt-10 lg:px-16",
           isSidebarCollapsed ? "md:ml-24" : "md:ml-72"
         )}
       >

--- a/client/src/components/add-expense-fab.tsx
+++ b/client/src/components/add-expense-fab.tsx
@@ -1,0 +1,17 @@
+import { AddExpenseModal } from "@/components/add-expense-modal";
+import { Button } from "@/components/ui/button";
+import { Plus } from "lucide-react";
+
+export function AddExpenseFab() {
+  return (
+    <AddExpenseModal>
+      <Button
+        size="icon"
+        className="fixed bottom-6 right-5 z-40 h-14 w-14 rounded-full bg-primary text-white shadow-xl shadow-primary/30 transition hover:scale-105 focus-visible:ring-2 focus-visible:ring-primary/40 focus-visible:ring-offset-2 focus-visible:ring-offset-background md:hidden"
+        aria-label="Quick add expense"
+      >
+        <Plus className="h-6 w-6" />
+      </Button>
+    </AddExpenseModal>
+  );
+}

--- a/client/src/components/add-expense-modal.tsx
+++ b/client/src/components/add-expense-modal.tsx
@@ -87,7 +87,10 @@ export function AddExpenseModal({ children }: AddExpenseModalProps) {
     <Modal open={open} onOpenChange={setOpen}>
       <ModalTrigger asChild>
         {children || (
-          <Button className="gap-2" data-testid="button-add-expense">
+          <Button
+            className="w-full gap-2 sm:w-auto"
+            data-testid="button-add-expense"
+          >
             <Plus className="h-5 w-5" />
             <span>Add Expense</span>
           </Button>

--- a/client/src/components/mobile-nav.tsx
+++ b/client/src/components/mobile-nav.tsx
@@ -1,0 +1,172 @@
+import { useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { Button } from "@/components/ui/button";
+import { ThemeToggle } from "@/components/theme-toggle";
+import { AddExpenseModal } from "@/components/add-expense-modal";
+import { navigation } from "@/components/sidebar";
+import { cn } from "@/lib/utils";
+import {
+  Menu,
+  Sparkles,
+  LogOut,
+  ChevronRight,
+  Plus,
+} from "lucide-react";
+import { Separator } from "@/components/ui/separator";
+import { useCurrentUser, currentUserQueryKey } from "@/hooks/use-current-user";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { supabase } from "@/lib/supabase";
+import { useToast } from "@/hooks/use-toast";
+import { extractErrorMessage } from "@/lib/errors";
+
+export function MobileNav() {
+  const [open, setOpen] = useState(false);
+  const location = useLocation();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+  const { data: user } = useCurrentUser();
+
+  const userInitial = user?.name?.[0] ?? user?.email?.[0] ?? "";
+
+  const logoutMutation = useMutation({
+    mutationFn: async () => {
+      const { error } = await supabase.auth.signOut();
+      if (error) throw error;
+    },
+    onSuccess: () => {
+      queryClient.setQueryData(currentUserQueryKey, null);
+      queryClient.clear();
+      toast({ title: "You have been logged out" });
+      setOpen(false);
+      navigate("/", { replace: true });
+    },
+    onError: (error: unknown) => {
+      toast({
+        title: "Unable to logout",
+        description: extractErrorMessage(error),
+        variant: "destructive",
+      });
+    },
+  });
+
+  const handleNavigate = (href: string) => {
+    setOpen(false);
+    navigate(href);
+  };
+
+  return (
+    <>
+      <div className="sticky top-0 z-40 flex items-center justify-between border-b border-white/60 bg-white/90 px-4 py-4 backdrop-blur-xl transition-colors dark:border-white/10 dark:bg-slate-950/75 md:hidden">
+        <div className="flex items-center gap-3">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-11 w-11 rounded-full border border-white/60 bg-white/80 text-foreground shadow-sm transition hover:bg-white/90 dark:border-white/10 dark:bg-slate-900/70 dark:hover:bg-slate-900/60"
+            onClick={() => setOpen(true)}
+            aria-label="Open navigation"
+          >
+            <Menu className="h-5 w-5" />
+          </Button>
+          <div>
+            <p className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.35em] text-muted-foreground">
+              <Sparkles className="h-4 w-4 text-primary" />
+              DollarTrack
+            </p>
+            <p className="text-sm text-muted-foreground/80">Budget smarter. Live better.</p>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <AddExpenseModal>
+            <Button
+              size="icon"
+              className="h-11 w-11 rounded-full border border-primary/20 bg-primary text-white shadow-lg shadow-primary/30 transition hover:bg-primary/90"
+              aria-label="Add expense"
+            >
+              <Plus className="h-5 w-5" />
+            </Button>
+          </AddExpenseModal>
+          <ThemeToggle className="h-11 w-11 rounded-full border border-white/60 bg-white/80 text-foreground shadow-sm hover:bg-white/90 dark:border-white/10 dark:bg-slate-900/70 dark:hover:bg-slate-900/60" />
+        </div>
+      </div>
+
+      <Sheet open={open} onOpenChange={setOpen}>
+        <SheetContent
+          side="left"
+          className="flex w-[320px] flex-col gap-6 border-white/40 bg-white/95 px-0 pb-8 pt-10 text-foreground backdrop-blur-2xl dark:border-white/10 dark:bg-slate-950/90"
+        >
+          <SheetHeader className="px-6 text-left">
+            <SheetTitle className="flex items-center gap-3 text-base font-semibold">
+              <span className="flex h-11 w-11 items-center justify-center rounded-2xl border border-white/60 bg-white/80 text-lg shadow-sm backdrop-blur dark:border-white/10 dark:bg-slate-900/70">
+                {userInitial || <Sparkles className="h-5 w-5" />}
+              </span>
+              <span className="flex flex-col">
+                <span>{user?.name || "Welcome back"}</span>
+                <span className="text-xs font-normal text-muted-foreground">
+                  {user?.email || "Stay on budget effortlessly"}
+                </span>
+              </span>
+            </SheetTitle>
+          </SheetHeader>
+
+          <div className="space-y-4">
+            <nav className="flex flex-col gap-1 px-4">
+              {navigation.map((item) => {
+                const href = "/app" + item.href;
+                const isActive =
+                  (location.pathname === "/app" && item.href === "/") ||
+                  location.pathname === href;
+                const Icon = item.icon;
+
+                return (
+                  <button
+                    key={item.name}
+                    type="button"
+                    onClick={() => handleNavigate(href)}
+                    className={cn(
+                      "group flex items-center justify-between rounded-2xl border border-transparent bg-white/40 px-4 py-4 text-left text-sm font-medium text-muted-foreground backdrop-blur transition dark:bg-white/5",
+                      isActive &&
+                        "border-primary/40 bg-primary/10 text-foreground shadow-md shadow-primary/10"
+                    )}
+                  >
+                    <span className="flex items-center gap-3">
+                      <span className="flex h-11 w-11 items-center justify-center rounded-2xl border border-white/60 bg-white/90 text-primary shadow-sm transition dark:border-white/10 dark:bg-slate-900/70">
+                        <Icon className="h-5 w-5" />
+                      </span>
+                      <span>{item.name}</span>
+                    </span>
+                    <ChevronRight className="h-4 w-4 opacity-60 transition group-hover:translate-x-0.5 group-hover:opacity-100" />
+                  </button>
+                );
+              })}
+            </nav>
+            <Separator className="mx-6 border-white/60 dark:border-white/10" />
+            <div className="flex flex-col gap-3 px-6">
+              <AddExpenseModal>
+                <Button className="w-full gap-2 rounded-2xl bg-primary text-white shadow-lg shadow-primary/20 transition hover:bg-primary/90">
+                  <Plus className="h-4 w-4" />
+                  Add Expense
+                </Button>
+              </AddExpenseModal>
+              <Button
+                variant="ghost"
+                className="w-full gap-2 rounded-2xl border border-white/60 bg-white/80 text-muted-foreground backdrop-blur transition hover:bg-white/90 dark:border-white/10 dark:bg-slate-900/70 dark:text-foreground"
+                onClick={() => logoutMutation.mutate()}
+                disabled={logoutMutation.isPending}
+              >
+                <LogOut className="h-4 w-4" />
+                Log out
+              </Button>
+            </div>
+          </div>
+        </SheetContent>
+      </Sheet>
+    </>
+  );
+}

--- a/client/src/components/page-layout.tsx
+++ b/client/src/components/page-layout.tsx
@@ -31,13 +31,14 @@ export function PageLayout({
   showThemeToggle = true,
 }: PageLayoutProps) {
   const childrenArray = Children.toArray(children);
+  const actionArray = actions ? Children.toArray(actions) : [];
 
   return (
-    <div className={cn("relative space-y-10 pb-16", className)}>
+    <div className={cn("relative space-y-12 pb-20", className)}>
       <div className="pointer-events-none absolute inset-x-0 -top-32 h-64 bg-gradient-to-b from-primary/12 via-transparent to-transparent dark:from-primary/20" />
       <div className="pointer-events-none absolute -bottom-24 left-1/2 h-60 w-[85%] -translate-x-1/2 rounded-[5rem] bg-gradient-to-r from-indigo-300/15 via-primary/10 to-purple-300/15 blur-3xl dark:from-indigo-500/20 dark:via-primary/15 dark:to-purple-500/20" />
 
-      <section className="relative overflow-hidden rounded-[2rem] border border-white/50 bg-gradient-to-br from-white/92 via-white/70 to-white/40 px-6 py-8 shadow-xl shadow-primary/10 backdrop-blur-2xl transition-colors dark:border-white/10 dark:from-slate-900/90 dark:via-slate-900/60 dark:to-slate-900/35">
+      <section className="relative overflow-hidden rounded-[2rem] border border-white/50 bg-gradient-to-br from-white/92 via-white/70 to-white/40 px-5 py-8 shadow-xl shadow-primary/10 backdrop-blur-2xl transition-colors sm:px-6 dark:border-white/10 dark:from-slate-900/90 dark:via-slate-900/60 dark:to-slate-900/35">
         <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(124,58,237,0.16),_transparent_60%)] opacity-80 dark:bg-[radial-gradient(circle_at_top,_rgba(129,140,248,0.22),_transparent_65%)]" />
         <div className="pointer-events-none absolute -top-24 -left-12 h-56 w-56 rounded-full bg-primary/25 blur-3xl opacity-70 dark:bg-primary/35" />
         <div className="pointer-events-none absolute -bottom-28 right-0 h-64 w-64 rounded-full bg-purple-400/20 blur-3xl opacity-70 dark:bg-purple-500/25" />
@@ -95,10 +96,22 @@ export function PageLayout({
               </div>
             </div>
           </div>
+
+          {actionArray.length > 0 ? (
+            <div className="flex flex-wrap items-center justify-start gap-3 self-start sm:justify-end">
+              {actionArray.map((action, index) => (
+                <div key={`page-action-${index}`} className="flex-shrink-0">
+                  {action}
+                </div>
+              ))}
+            </div>
+          ) : null}
         </div>
 
         {headerContent ? (
-          <div className="relative mt-8">{headerContent}</div>
+          <div className="relative mt-8 space-y-6 sm:space-y-8">
+            {headerContent}
+          </div>
         ) : null}
       </section>
 

--- a/client/src/components/sidebar.tsx
+++ b/client/src/components/sidebar.tsx
@@ -30,7 +30,7 @@ type SidebarProps = {
   onToggle: () => void;
 };
 
-const navigation = [
+export const navigation = [
   { name: "Dashboard", href: "/", icon: LayoutDashboard },
   { name: "Expenses", href: "/expenses", icon: CreditCard },
   { name: "Analytics", href: "/analytics", icon: LineChart },
@@ -73,7 +73,7 @@ export function Sidebar({ collapsed, onToggle }: SidebarProps) {
     <aside
       data-collapsed={collapsed ? "true" : undefined}
       className={cn(
-        "fixed left-0 top-0 z-40 flex h-full flex-col border-r border-white/60 bg-white/85 shadow-2xl backdrop-blur-2xl transition-all duration-300 dark:border-white/10 dark:bg-slate-950/70",
+        "fixed left-0 top-0 z-40 hidden h-full flex-col border-r border-white/60 bg-white/85 shadow-2xl backdrop-blur-2xl transition-all duration-300 dark:border-white/10 dark:bg-slate-950/70 md:flex",
         collapsed ? "w-24" : "w-72"
       )}
     >

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -9,6 +9,7 @@ import { RecentExpenses } from "@/components/recent-expenses";
 import { ExpenseFiltersSheet } from "@/components/expense-filters";
 import { ActiveExpenseFilters } from "@/components/active-expense-filters";
 import { PageLayout } from "@/components/page-layout";
+import { AddExpenseFab } from "@/components/add-expense-fab";
 
 export default function Dashboard() {
   const [isFilterSheetOpen, setIsFilterSheetOpen] = useState(false);
@@ -29,7 +30,7 @@ export default function Dashboard() {
         <>
           <Button
             variant="outline"
-            className="gap-2 rounded-full border-white/50 bg-white/70 px-5 text-foreground shadow-sm backdrop-blur hover:bg-white/90 dark:border-white/10 dark:bg-slate-900/60 dark:hover:bg-slate-900/70"
+            className="w-full gap-2 rounded-full border-white/50 bg-white/70 px-5 text-foreground shadow-sm backdrop-blur hover:bg-white/90 dark:border-white/10 dark:bg-slate-900/60 dark:hover:bg-slate-900/70 sm:w-auto"
             data-testid="button-filter"
             onClick={() => setIsFilterSheetOpen(true)}
           >
@@ -58,6 +59,8 @@ export default function Dashboard() {
       </div>
 
       <RecentExpenses />
+
+      <AddExpenseFab />
     </PageLayout>
   );
 }

--- a/client/src/pages/expenses.tsx
+++ b/client/src/pages/expenses.tsx
@@ -6,6 +6,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { AddExpenseModal } from "@/components/add-expense-modal";
+import { AddExpenseFab } from "@/components/add-expense-fab";
 import { getCategoryIcon } from "@/lib/categories";
 import { type ExpenseWithCategory, type Category } from "@shared/schema";
 import { fetchExpenses, fetchCategories } from "@/lib/api";
@@ -116,7 +117,7 @@ export default function Expenses() {
         <>
           <Button
             variant="outline"
-            className="gap-2 rounded-full border-white/60 bg-white/70 px-5 text-foreground shadow-sm backdrop-blur hover:bg-white/90 dark:border-white/10 dark:bg-slate-900/60 dark:hover:bg-slate-900/70"
+            className="w-full gap-2 rounded-full border-white/60 bg-white/70 px-5 text-foreground shadow-sm backdrop-blur hover:bg-white/90 dark:border-white/10 dark:bg-slate-900/60 dark:hover:bg-slate-900/70 sm:w-auto"
             data-testid="button-filter-expenses"
             onClick={() => setIsFilterSheetOpen(true)}
           >
@@ -278,6 +279,8 @@ export default function Expenses() {
           )}
         </CardContent>
       </Card>
+
+      <AddExpenseFab />
     </PageLayout>
   );
 }


### PR DESCRIPTION
## Summary
- add a dedicated mobile navigation experience with quick access to add expenses and logout
- refine the protected layout and shared page header so actions display responsively on small screens
- introduce a mobile floating add-expense shortcut and ensure add buttons expand to full width on phones

## Testing
- npm run build
- npm run lint *(fails: ESLint couldn't find an eslint.config)*

------
https://chatgpt.com/codex/tasks/task_e_68d52a2e4d78832197a133cd15cfcbad