### PR TITLE
Enhance expenses filtering and refresh navigation styling

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -134,15 +134,13 @@ function PublicLayout() {
   );
 
   return (
-    <div className="relative min-h-screen overflow-hidden bg-transparent text-foreground transition-colors">
-      <div className="pointer-events-none absolute inset-0 -z-10">
-        <div className="absolute inset-0 bg-[radial-gradient(circle_at_10%_15%,rgba(129,140,248,0.25),transparent_55%),radial-gradient(circle_at_82%_-10%,rgba(236,72,153,0.2),transparent_60%),radial-gradient(circle_at_18%_82%,rgba(56,189,248,0.16),transparent_55%),linear-gradient(180deg,rgba(255,255,255,0.96),rgba(242,247,255,0.98))] opacity-95 dark:bg-[radial-gradient(circle_at_15%_-10%,rgba(99,102,241,0.32),transparent_60%),radial-gradient(circle_at_80%_8%,rgba(168,85,247,0.24),transparent_60%),radial-gradient(circle_at_18%_80%,rgba(15,118,110,0.2),transparent_65%),linear-gradient(180deg,rgba(10,12,28,0.94),rgba(2,6,23,0.98))]" />
-        <div className="absolute -left-24 top-32 h-72 w-72 rounded-full bg-primary/18 blur-3xl dark:bg-primary/30" />
-        <div className="absolute right-[-20%] bottom-10 h-[22rem] w-[22rem] rounded-full bg-purple-200/45 blur-3xl dark:bg-purple-500/25" />
-      </div>
+    <div className="relative min-h-screen overflow-hidden text-foreground transition-colors">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(129,140,248,0.2),_transparent_58%),radial-gradient(circle_at_bottom,_rgba(236,72,153,0.1),_transparent_62%)] dark:bg-[radial-gradient(circle_at_top,_rgba(79,70,229,0.38),_transparent_55%),radial-gradient(circle_at_bottom,_rgba(15,23,42,0.82),_transparent_72%)]" />
+      <div className="pointer-events-none absolute -left-24 top-28 h-[20rem] w-[20rem] rounded-full bg-sky-200/50 blur-3xl dark:bg-sky-500/25" />
+      <div className="pointer-events-none absolute right-[-12rem] bottom-[-7rem] h-[22rem] w-[22rem] rounded-full bg-purple-200/40 blur-3xl dark:bg-purple-600/20" />
+
       <header className="relative z-10 mx-auto flex w-full max-w-6xl flex-col gap-6 px-6 py-6 items-center sm:py-8 md:flex-row md:items-center md:justify-between">
         <div className="flex items-center w-full justify-between sm:w-auto gap-3">
-          <ThemeToggle className="h-9 w-9 shrink-0 border border-primary/10 bg-white/70 text-foreground shadow-sm hover:bg-white/80 dark:border-white/10 dark:bg-slate-900/60" />
           <Link to="/" className="no-underline">
             <p className="text-xs font-semibold uppercase tracking-[0.35em] text-muted-foreground">
               DollarTrack
@@ -150,7 +148,8 @@ function PublicLayout() {
             <p className="text-sm text-muted-foreground/80">
               Budget smarter. Live better.
             </p>
-          </Link>
+          </Link>{" "}
+          <ThemeToggle className="h-9 w-9 shrink-0 border border-primary/10 bg-white/70 text-foreground shadow-sm hover:bg-white/80 dark:border-white/10 dark:bg-slate-900/60" />
         </div>
 
         <nav className="flex flex-wrap items-center gap-3 text-sm text-muted-foreground">

--- a/client/src/components/sidebar.tsx
+++ b/client/src/components/sidebar.tsx
@@ -73,7 +73,10 @@ export function Sidebar({ collapsed, onToggle }: SidebarProps) {
     <aside
       data-collapsed={collapsed ? "true" : undefined}
       className={cn(
-        "fixed left-0 top-0 z-40 hidden h-full flex-col border-r border-white/60 bg-white/85 shadow-2xl backdrop-blur-2xl transition-all duration-300 dark:border-white/10 dark:bg-slate-950/70 lg:flex",
+        "relative fixed left-0 top-0 z-40 hidden h-full flex-col overflow-hidden border-r border-white/60 bg-white/80 shadow-2xl backdrop-blur-2xl transition-all duration-300 dark:border-white/10 dark:bg-slate-950/70 lg:flex",
+        "before:pointer-events-none before:absolute before:inset-0 before:-z-10 before:bg-gradient-to-br before:from-primary/5 before:via-white/60 before:to-white/20 before:opacity-80 before:blur-xl",
+        "after:pointer-events-none after:absolute after:-left-24 after:top-24 after:-z-10 after:h-64 after:w-64 after:rounded-full after:bg-primary/30 after:opacity-30 after:blur-3xl",
+        "dark:before:from-primary/10 dark:before:via-slate-950/70 dark:before:to-slate-900/40 dark:after:bg-primary/20",
         collapsed ? "w-24" : "w-72"
       )}
     >
@@ -153,15 +156,22 @@ export function Sidebar({ collapsed, onToggle }: SidebarProps) {
                     data-testid={`nav-link-${item.name.toLowerCase()}`}
                     aria-current={isActive ? "page" : undefined}
                     className={cn(
-                      "group flex items-center rounded-2xl text-sm font-medium transition-all",
+                      "group relative flex items-center overflow-hidden rounded-2xl border border-transparent text-sm font-medium transition-all",
                       collapsed
                         ? "justify-center gap-0 px-2 py-3"
                         : "gap-3 px-4 py-3",
                       isActive
-                        ? "bg-gradient-to-r from-primary via-primary/80 to-primary/60 text-white shadow-lg shadow-primary/30"
-                        : "text-muted-foreground hover:bg-white/70 hover:text-foreground dark:hover:bg-white/10"
+                        ? "border-primary/30 bg-gradient-to-r from-primary/90 via-primary/80 to-primary/60 text-white shadow-lg shadow-primary/30"
+                        : "text-muted-foreground hover:border-white/60 hover:bg-white/70 hover:text-foreground dark:hover:border-white/15 dark:hover:bg-white/10"
                     )}
                   >
+                    <span
+                      className="pointer-events-none absolute inset-0 -z-10 opacity-0 transition-opacity duration-300 group-hover:opacity-100"
+                      style={{
+                        background:
+                          "radial-gradient(circle at 20% 20%, rgba(99,102,241,0.12), transparent 55%)",
+                      }}
+                    />
                     <span
                       className={cn(
                         "flex h-11 w-11 items-center justify-center rounded-2xl border border-white/60 bg-white/80 text-primary shadow-sm backdrop-blur transition-all dark:border-white/10 dark:bg-slate-900/70",

--- a/client/src/pages/categories.tsx
+++ b/client/src/pages/categories.tsx
@@ -397,8 +397,10 @@ export default function Categories() {
         </div>
       }
     >
-      <Card>
-        <CardHeader className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+      <Card className="relative overflow-hidden border-transparent bg-gradient-to-br from-white/85 via-white/55 to-white/35 shadow-[0_24px_70px_rgba(15,23,42,0.08)] backdrop-blur-3xl dark:from-slate-950/85 dark:via-slate-900/55 dark:to-slate-900/35">
+        <div className="pointer-events-none absolute inset-x-12 -top-24 h-40 rounded-full bg-primary/15 blur-3xl dark:bg-primary/25" />
+        <div className="pointer-events-none absolute inset-x-0 bottom-0 h-40 bg-gradient-to-t from-primary/10 via-transparent to-transparent blur-3xl dark:from-primary/20" />
+        <CardHeader className="relative z-10 flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
           <div>
             <CardTitle className="text-2xl">Manage Categories</CardTitle>
             <p className="text-sm text-muted-foreground">
@@ -407,31 +409,43 @@ export default function Categories() {
             </p>
           </div>
         </CardHeader>
-        <CardContent className="space-y-6">
-          <div className="relative max-w-md">
-            <Input
-              type="text"
-              placeholder="Search by name or icon..."
-              value={searchQuery}
-              onChange={(event) => setSearchQuery(event.target.value)}
-              className="rounded-2xl border border-border pl-11 pr-4 text-base"
-              data-testid="input-search-categories"
-            />
-            <Search className="pointer-events-none absolute left-4 top-3.5 h-4 w-4 text-muted-foreground" />
+        <CardContent className="relative z-10 space-y-7">
+          <div className="rounded-3xl border border-white/60 bg-white/75 p-4 shadow-inner backdrop-blur-xl dark:border-white/10 dark:bg-slate-900/70 sm:p-5">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <div className="relative w-full sm:max-w-md">
+                <Input
+                  type="text"
+                  placeholder="Search by name or icon..."
+                  value={searchQuery}
+                  onChange={(event) => setSearchQuery(event.target.value)}
+                  className="h-11 rounded-full border-white/50 bg-white/90 pl-11 pr-4 text-sm shadow-sm focus-visible:ring-2 focus-visible:ring-primary/60 dark:border-white/10 dark:bg-slate-900/70 dark:text-foreground"
+                  data-testid="input-search-categories"
+                />
+                <Search className="pointer-events-none absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              </div>
+              <div className="flex gap-2">
+                <Badge className="rounded-full border border-white/60 bg-white/80 px-3 py-1 text-[11px] font-medium text-muted-foreground shadow-sm dark:border-white/10 dark:bg-slate-900/60">
+                  {filteredCategories.length} showing
+                </Badge>
+                <Badge className="rounded-full border border-white/60 bg-white/80 px-3 py-1 text-[11px] font-medium text-muted-foreground shadow-sm dark:border-white/10 dark:bg-slate-900/60">
+                  {categories?.length ?? 0} total
+                </Badge>
+              </div>
+            </div>
           </div>
 
           {isLoading ? (
-            <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+            <div className="grid gap-5 sm:grid-cols-2 xl:grid-cols-3">
               {Array.from({ length: 6 }).map((_, index) => (
                 <div
                   key={index}
-                  className="h-32 animate-pulse rounded-3xl border border-white/60 bg-white/70 backdrop-blur dark:border-white/10 dark:bg-slate-900/60"
+                  className="h-36 animate-pulse rounded-3xl border border-white/40 bg-white/55 shadow-inner dark:border-white/10 dark:bg-slate-900/60"
                 />
               ))}
             </div>
           ) : filteredCategories.length === 0 ? (
-            <div className="flex flex-col items-center justify-center space-y-4 rounded-3xl border border-dashed border-border bg-white/50 py-16 text-center dark:border-white/10 dark:bg-slate-900/40">
-              <div className="flex h-16 w-16 items-center justify-center rounded-2xl border border-dashed border-border text-muted-foreground dark:border-white/20">
+            <div className="flex flex-col items-center justify-center space-y-4 rounded-3xl border border-dashed border-white/60 bg-white/60 py-16 text-center shadow-inner dark:border-white/10 dark:bg-slate-900/50">
+              <div className="flex h-16 w-16 items-center justify-center rounded-2xl border border-dashed border-white/70 text-muted-foreground dark:border-white/20">
                 <Plus className="h-7 w-7" />
               </div>
               <div>
@@ -446,73 +460,94 @@ export default function Categories() {
                     : "Create categories to organize your expenses."}
                 </p>
               </div>
-              <Button className="gap-2" onClick={() => setIsCreateOpen(true)}>
+              <Button
+                className="gap-2 rounded-full px-5"
+                onClick={() => setIsCreateOpen(true)}
+              >
                 <Plus className="h-5 w-5" />
                 Add your first category
               </Button>
             </div>
           ) : (
-            <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+            <div className="grid gap-5 sm:grid-cols-2 xl:grid-cols-3">
               {filteredCategories.map((category) => {
                 const Icon = getCategoryIcon(category.icon);
                 return (
                   <div
                     key={category.id}
-                    className="group relative flex flex-col rounded-2xl border border-white/60 bg-white/80 p-4 shadow-md backdrop-blur-xl transition hover:border-primary/40 hover:shadow-lg dark:border-white/10 dark:bg-slate-900/60"
+                    className="group relative flex flex-col overflow-hidden rounded-3xl border bg-white/85 p-5 shadow-[0_25px_45px_-24px_rgba(15,23,42,0.25)] backdrop-blur-xl transition hover:-translate-y-1 hover:shadow-[0_35px_55px_-20px_rgba(79,70,229,0.3)] dark:border-white/10 dark:bg-slate-900/65"
+                    style={{
+                      borderColor: `${category.color}33`,
+                    }}
                     data-testid={`category-card-${category.id}`}
                   >
-                    {/* Header: icon + name + color pill */}
-                    <div className="flex items-start justify-between gap-3 min-w-0">
-                      <div className="flex items-center gap-3 sm:gap-4 min-w-0">
+                    <span
+                      className="pointer-events-none absolute -right-16 top-0 h-40 w-40 rounded-full opacity-20 blur-3xl"
+                      style={{ backgroundColor: category.color }}
+                    />
+                    <span
+                      className="pointer-events-none absolute -bottom-12 left-1/4 h-36 w-36 rounded-full opacity-15 blur-3xl"
+                      style={{ backgroundColor: category.color }}
+                    />
+                    <div className="flex items-start justify-between gap-4">
+                      <div className="flex min-w-0 items-center gap-4">
                         <div
-                          className="flex h-10 w-10 sm:h-12 sm:w-12 items-center justify-center rounded-2xl shrink-0"
+                          className="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl border border-white/60 text-lg font-semibold shadow-sm backdrop-blur dark:border-white/10"
                           style={{
                             backgroundColor: `${category.color}1a`,
                             color: category.color,
                           }}
                         >
-                          <Icon className="h-5 w-5 sm:h-6 sm:w-6" />
+                          <Icon className="h-5 w-5" />
                         </div>
-
                         <div className="min-w-0">
-                          <h3 className="text-base sm:text-lg font-semibold text-foreground truncate">
+                          <h3 className="truncate text-lg font-semibold text-foreground">
                             {category.name}
                           </h3>
-                          <p className="text-xs sm:text-sm text-muted-foreground">
+                          <p className="text-xs text-muted-foreground">
                             {formatIconName(category.icon)} icon
                           </p>
                         </div>
                       </div>
-
                       <Badge
                         variant="outline"
-                        className="rounded-full border border-white/60 bg-white/70 px-2.5 py-1 text-[10px] sm:text-xs font-medium whitespace-nowrap backdrop-blur dark:border-white/10 dark:bg-slate-900/60"
+                        className="rounded-full border border-white/60 bg-white/80 px-2.5 py-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground backdrop-blur dark:border-white/10 dark:bg-slate-900/60"
                         style={{ color: category.color }}
                       >
                         {category.color}
                       </Badge>
                     </div>
 
-                    {/* Footer: description + actions */}
-                    <div className="mt-4 sm:mt-6  flex items-center gap-1">
-                      {/* Desktop / tablet: text buttons */}
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => setEditingCategory(category)}
-                        data-testid={`button-edit-category-${category.id}`}
-                      >
-                        <Pencil className="h-4 w-4" />
-                      </Button>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        className="text-destructive hover:text-destructive"
-                        onClick={() => setCategoryToDelete(category)}
-                        data-testid={`button-delete-category-${category.id}`}
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </Button>
+                    <div className="mt-5 flex items-center justify-between gap-3">
+                      <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                        <Badge
+                          variant="secondary"
+                          className="rounded-full border border-white/50 bg-white/80 px-2.5 py-1 text-[11px] font-medium backdrop-blur dark:border-white/10 dark:bg-slate-900/60"
+                          style={{ color: category.color }}
+                        >
+                          {formatIconName(category.icon)}
+                        </Badge>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="h-9 w-9 rounded-full border border-white/60 bg-white/75 text-muted-foreground shadow-sm backdrop-blur transition hover:border-primary/40 hover:text-primary dark:border-white/10 dark:bg-slate-900/60 dark:hover:bg-slate-900/70"
+                          onClick={() => setEditingCategory(category)}
+                          data-testid={`button-edit-category-${category.id}`}
+                        >
+                          <Pencil className="h-4 w-4" />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="h-9 w-9 rounded-full border border-white/60 bg-white/75 text-muted-foreground shadow-sm backdrop-blur transition hover:border-destructive/40 hover:text-destructive dark:border-white/10 dark:bg-slate-900/60 dark:hover:bg-slate-900/70"
+                          onClick={() => setCategoryToDelete(category)}
+                          data-testid={`button-delete-category-${category.id}`}
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      </div>
                     </div>
                   </div>
                 );

--- a/client/src/pages/expenses.tsx
+++ b/client/src/pages/expenses.tsx
@@ -20,6 +20,7 @@ import { PageLayout } from "@/components/page-layout";
 import { AnimatePresence, motion } from "framer-motion";
 import { EditExpenseModal } from "@/components/edit-expense-modal";
 import { useToast } from "@/hooks/use-toast";
+import { cn } from "@/lib/utils";
 import {
   Modal,
   ModalContent,
@@ -32,7 +33,7 @@ import {
 export default function Expenses() {
   const [searchQuery, setSearchQuery] = useState("");
   const [isFilterSheetOpen, setIsFilterSheetOpen] = useState(false);
-  const { filters } = useExpenseFilters();
+  const { filters, setFilters } = useExpenseFilters();
   const queryClient = useQueryClient();
   const { toast } = useToast();
 
@@ -48,6 +49,22 @@ export default function Expenses() {
 
   const [expenseToDelete, setExpenseToDelete] =
     useState<ExpenseWithCategory | null>(null);
+
+  const toggleQuickCategory = (categoryId: string) => {
+    setFilters((previous) => {
+      const alreadySelected = previous.categories.includes(categoryId);
+      if (alreadySelected) {
+        return {
+          ...previous,
+          categories: previous.categories.filter((id) => id !== categoryId),
+        };
+      }
+      return {
+        ...previous,
+        categories: [...previous.categories, categoryId],
+      };
+    });
+  };
 
   const filteredExpenses = useMemo(() => {
     if (!expenses) return [];
@@ -193,29 +210,58 @@ export default function Expenses() {
             </div>
 
             {/* Search card */}
-            <div className="rounded-2xl border border-white/60 bg-white/80 p-4 sm:p-6 shadow-xl backdrop-blur-xl dark:border-white/10 dark:bg-slate-900/70">
-              <div className="relative">
-                <Input
-                  type="text"
-                  placeholder="Search expenses or categories..."
-                  value={searchQuery}
-                  onChange={(e) => setSearchQuery(e.target.value)}
-                  className="pl-10 pr-3 h-11 text-sm sm:text-base"
-                  data-testid="input-search-all-expenses"
-                />
-                <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+            <div className="rounded-3xl border border-white/60 bg-white/80 p-4 sm:p-6 shadow-xl backdrop-blur-xl dark:border-white/10 dark:bg-slate-900/70">
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
+                <div className="relative flex-1">
+                  <Input
+                    type="text"
+                    placeholder="Search expenses or categories..."
+                    value={searchQuery}
+                    onChange={(e) => setSearchQuery(e.target.value)}
+                    className="h-11 pl-10 pr-3 text-sm sm:text-base"
+                    data-testid="input-search-all-expenses"
+                  />
+                  <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                </div>
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="h-11 gap-2 rounded-full border-white/70 bg-white/70 text-sm font-medium text-foreground shadow-sm backdrop-blur transition hover:bg-white/90 dark:border-white/10 dark:bg-slate-900/60 dark:hover:bg-slate-900/70"
+                  onClick={() => setIsFilterSheetOpen(true)}
+                >
+                  <Filter className="h-4 w-4" />
+                  Advanced filters
+                </Button>
               </div>
               <ActiveExpenseFilters className="mt-3 sm:mt-4" />
               <div className="mt-3 sm:mt-4 flex flex-wrap gap-2">
-                {categories?.slice(0, 6).map((category) => (
-                  <Badge
-                    key={category.id}
-                    variant="secondary"
-                    className="rounded-full border border-white/40 bg-white/70 px-2.5 py-1 text-[11px] sm:text-xs font-medium text-muted-foreground backdrop-blur dark:border-white/10 dark:bg-slate-900/60"
-                  >
-                    {category.name}
-                  </Badge>
-                ))}
+                {categories?.slice(0, 8).map((category) => {
+                  const isSelected = filters.categories.includes(category.id);
+                  return (
+                    <button
+                      key={category.id}
+                      type="button"
+                      onClick={() => toggleQuickCategory(category.id)}
+                      className={cn(
+                        "inline-flex items-center gap-2 rounded-full border px-3 py-1 text-[11px] font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 sm:text-xs",
+                        "backdrop-blur",
+                        isSelected
+                          ? "border-primary/40 bg-primary/10 text-primary shadow-sm"
+                          : "border-white/60 bg-white/70 text-muted-foreground hover:border-primary/30 hover:text-primary dark:border-white/10 dark:bg-slate-900/60 dark:hover:bg-slate-900/70"
+                      )}
+                      aria-pressed={isSelected}
+                    >
+                      <span className="block max-w-[8rem] truncate sm:max-w-none">
+                        {category.name}
+                      </span>
+                      {isSelected ? (
+                        <span className="hidden text-[10px] uppercase tracking-wide sm:inline">
+                          Active
+                        </span>
+                      ) : null}
+                    </button>
+                  );
+                })}
               </div>
             </div>
           </div>

--- a/client/src/pages/landing.tsx
+++ b/client/src/pages/landing.tsx
@@ -30,11 +30,6 @@ export default function Landing() {
 
   return (
     <div>
-      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(129,140,248,0.18),_transparent_60%),radial-gradient(circle_at_bottom,_rgba(236,72,153,0.1),_transparent_60%)] dark:bg-[radial-gradient(circle_at_top,_rgba(79,70,229,0.35),_transparent_55%),radial-gradient(circle_at_bottom,_rgba(15,23,42,0.85),_transparent_72%)]" />
-      <div className="pointer-events-none absolute -top-48 left-1/2 h-[28rem] w-[28rem] -translate-x-1/2 rounded-full bg-gradient-to-br from-primary/25 via-transparent to-transparent blur-3xl opacity-80 dark:from-primary/35" />
-      <div className="pointer-events-none absolute -left-24 top-[18%] h-72 w-72 rounded-full bg-sky-200/50 blur-3xl dark:bg-sky-500/25" />
-      <div className="pointer-events-none absolute -right-20 bottom-[-9rem] h-[24rem] w-[24rem] rounded-full bg-purple-200/40 blur-3xl dark:bg-purple-600/20" />
-
       <main className="relative z-10 mx-auto flex w-full max-w-6xl flex-col gap-16 px-5 pb-6 sm:pb-24 pt-10 sm:px-6 md:gap-20 md:pt-12">
         <section className="relative grid gap-10 overflow-hidden rounded-[2.5rem] border border-white/70 bg-white/90 p-6 shadow-[0_32px_90px_rgba(124,58,237,0.12)] backdrop-blur-xl dark:border-white/10 dark:bg-slate-900/75 md:grid-cols-[1.05fr,0.95fr] md:items-center md:p-10">
           <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_left,_rgba(129,140,248,0.16),_transparent_58%)] opacity-80 dark:bg-[radial-gradient(circle_at_top_left,_rgba(99,102,241,0.24),_transparent_60%)]" />

--- a/client/src/pages/login.tsx
+++ b/client/src/pages/login.tsx
@@ -77,10 +77,6 @@ export default function Login() {
 
   return (
     <div className="mt-4 sm:mt-10">
-      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(129,140,248,0.18),_transparent_58%),radial-gradient(circle_at_bottom,_rgba(236,72,153,0.08),_transparent_62%)] dark:bg-[radial-gradient(circle_at_top,_rgba(79,70,229,0.35),_transparent_55%),radial-gradient(circle_at_bottom,_rgba(15,23,42,0.82),_transparent_72%)]" />
-      <div className="pointer-events-none absolute -left-24 top-24 h-72 w-72 rounded-full bg-sky-200/50 blur-3xl dark:bg-sky-500/25" />
-      <div className="pointer-events-none absolute right-[-10rem] bottom-[-7rem] h-[20rem] w-[20rem] rounded-full bg-purple-200/40 blur-3xl dark:bg-purple-600/20" />
-
       <div className="relative z-10 mx-auto flex h-full max-w-5xl flex-col px-5 py-6 sm:px-6">
         <div className="relative flex flex-1 items-center justify-center">
           <div className="pointer-events-none absolute -left-6 top-10 h-44 w-44 rounded-full bg-primary/10 blur-3xl dark:bg-primary/20" />

--- a/client/src/pages/register.tsx
+++ b/client/src/pages/register.tsx
@@ -100,10 +100,6 @@ export default function Register() {
 
   return (
     <div className="mt-2">
-      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(129,140,248,0.2),_transparent_58%),radial-gradient(circle_at_bottom,_rgba(236,72,153,0.1),_transparent_62%)] dark:bg-[radial-gradient(circle_at_top,_rgba(79,70,229,0.38),_transparent_55%),radial-gradient(circle_at_bottom,_rgba(15,23,42,0.82),_transparent_72%)]" />
-      <div className="pointer-events-none absolute -left-24 top-28 h-[20rem] w-[20rem] rounded-full bg-sky-200/50 blur-3xl dark:bg-sky-500/25" />
-      <div className="pointer-events-none absolute right-[-12rem] bottom-[-7rem] h-[22rem] w-[22rem] rounded-full bg-purple-200/40 blur-3xl dark:bg-purple-600/20" />
-
       <div className="relative z-10 mx-auto flex max-w-5xl flex-col px-5 py-6 sm:px-6">
         <div className="relative flex flex-1 items-center justify-center">
           <div className="pointer-events-none absolute -left-10 top-16 h-52 w-52 rounded-full bg-primary/10 blur-3xl dark:bg-primary/22" />


### PR DESCRIPTION
## Summary
- refresh the categories management card with glassmorphism styling that adapts to mobile and desktop
- add quick expense category toggles and an advanced filter button for easier filtering
- polish the sidebar visuals with gradient backdrops and richer hover states

## Testing
- npm run lint *(fails: ESLint configuration missing in repo)*

------
https://chatgpt.com/codex/tasks/task_e_68d64964d06883219c6749fada7f0251