### PR TITLE
Refine filter panel layout and light theme navigation

### DIFF
--- a/client/src/components/expense-filters.tsx
+++ b/client/src/components/expense-filters.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/components/ui/sheet";
 import { fetchCategories } from "@/lib/api";
 import { useExpenseFilters } from "@/hooks/use-expense-filters";
+import { cn } from "@/lib/utils";
 import type { Category } from "@shared/schema";
 
 type ExpenseFiltersSheetProps = {
@@ -94,7 +95,9 @@ export function ExpenseFiltersSheet({
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent className="flex w-full flex-col gap-6 sm:max-w-md">
+      <SheetContent
+        className="flex w-full flex-col gap-6 rounded-none border border-white/70 bg-gradient-to-b from-white/95 via-white/90 to-white/80 p-6 shadow-[0_24px_80px_rgba(15,23,42,0.12)] backdrop-blur-2xl dark:border-white/10 dark:from-slate-950/90 dark:via-slate-950/80 dark:to-slate-950/70 dark:shadow-[0_24px_80px_rgba(15,23,42,0.45)] sm:rounded-l-[32px]"
+      >
         <SheetHeader>
           <SheetTitle>Filter expenses</SheetTitle>
           <SheetDescription>{selectedSummary}</SheetDescription>
@@ -108,7 +111,7 @@ export function ExpenseFiltersSheet({
                 Choose one or multiple categories to narrow down results.
               </p>
             </div>
-            <ScrollArea className="h-48 rounded-xl border border-dashed border-muted-foreground/20 p-3">
+            <ScrollArea className="h-48 rounded-2xl border border-white/60 bg-white/70 p-3 shadow-inner backdrop-blur dark:border-white/10 dark:bg-slate-950/60">
               <div className="space-y-3">
                 {isLoading ? (
                   <div className="space-y-3">
@@ -126,7 +129,11 @@ export function ExpenseFiltersSheet({
                       <Label
                         key={category.id}
                         htmlFor={`filter-category-${category.id}`}
-                        className="flex cursor-pointer items-center gap-3 rounded-lg border border-transparent px-3 py-2 text-sm transition-colors hover:border-primary/40 hover:bg-primary/5"
+                        className={cn(
+                          "flex cursor-pointer items-center gap-3 rounded-xl border border-transparent px-3 py-2 text-sm font-medium text-foreground transition-colors hover:border-primary/30 hover:bg-primary/5 hover:text-primary",
+                          isChecked &&
+                            "border-primary/40 bg-primary/10 text-primary shadow-sm dark:border-primary/30 dark:bg-primary/15 dark:text-primary-foreground"
+                        )}
                       >
                         <Checkbox
                           id={`filter-category-${category.id}`}
@@ -169,7 +176,7 @@ export function ExpenseFiltersSheet({
                 </Button>
               )}
             </div>
-            <div className="rounded-xl border border-muted-foreground/20 p-3">
+            <div className="rounded-2xl border border-white/60 bg-white/70 p-3 shadow-inner backdrop-blur dark:border-white/10 dark:bg-slate-950/60">
               <Calendar
                 mode="range"
                 numberOfMonths={1}

--- a/client/src/components/expense-filters.tsx
+++ b/client/src/components/expense-filters.tsx
@@ -96,114 +96,118 @@ export function ExpenseFiltersSheet({
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
       <SheetContent
-        className="flex w-full flex-col gap-6 rounded-none border border-white/70 bg-gradient-to-b from-white/95 via-white/90 to-white/80 p-6 shadow-[0_24px_80px_rgba(15,23,42,0.12)] backdrop-blur-2xl dark:border-white/10 dark:from-slate-950/90 dark:via-slate-950/80 dark:to-slate-950/70 dark:shadow-[0_24px_80px_rgba(15,23,42,0.45)] sm:rounded-l-[32px]"
+        className="flex h-dvh w-full flex-col gap-6 overflow-hidden rounded-none border border-white/70 bg-gradient-to-b from-white/95 via-white/90 to-white/80 p-6 shadow-[0_24px_80px_rgba(15,23,42,0.12)] backdrop-blur-2xl dark:border-white/10 dark:from-slate-950/90 dark:via-slate-950/80 dark:to-slate-950/70 dark:shadow-[0_24px_80px_rgba(15,23,42,0.45)] sm:h-auto sm:max-h-[calc(100vh-4rem)] sm:rounded-l-[32px]"
       >
-        <SheetHeader>
-          <SheetTitle>Filter expenses</SheetTitle>
-          <SheetDescription>{selectedSummary}</SheetDescription>
-        </SheetHeader>
+        <div className="flex h-full flex-col gap-6">
+          <SheetHeader>
+            <SheetTitle>Filter expenses</SheetTitle>
+            <SheetDescription>{selectedSummary}</SheetDescription>
+          </SheetHeader>
 
-        <div className="flex-1 space-y-6">
-          <div className="space-y-4">
-            <div>
-              <h3 className="text-sm font-medium text-foreground">Categories</h3>
-              <p className="text-xs text-muted-foreground">
-                Choose one or multiple categories to narrow down results.
-              </p>
-            </div>
-            <ScrollArea className="h-48 rounded-2xl border border-white/60 bg-white/70 p-3 shadow-inner backdrop-blur dark:border-white/10 dark:bg-slate-950/60">
-              <div className="space-y-3">
-                {isLoading ? (
-                  <div className="space-y-3">
-                    {Array.from({ length: 5 }).map((_, index) => (
-                      <div
-                        key={index}
-                        className="h-10 animate-pulse rounded-lg bg-muted/60"
-                      />
-                    ))}
-                  </div>
-                ) : categories && categories.length > 0 ? (
-                  categories.map((category) => {
-                    const isChecked = selectedCategoryIds.includes(category.id);
-                    return (
-                      <Label
-                        key={category.id}
-                        htmlFor={`filter-category-${category.id}`}
-                        className={cn(
-                          "flex cursor-pointer items-center gap-3 rounded-xl border border-transparent px-3 py-2 text-sm font-medium text-foreground transition-colors hover:border-primary/30 hover:bg-primary/5 hover:text-primary",
-                          isChecked &&
-                            "border-primary/40 bg-primary/10 text-primary shadow-sm dark:border-primary/30 dark:bg-primary/15 dark:text-primary-foreground"
-                        )}
-                      >
-                        <Checkbox
-                          id={`filter-category-${category.id}`}
-                          checked={isChecked}
-                          onCheckedChange={(value) =>
-                            toggleCategory(category.id, value === true)
-                          }
-                        />
-                        <span className="font-medium text-foreground">
-                          {category.name}
-                        </span>
-                      </Label>
-                    );
-                  })
-                ) : (
-                  <p className="text-sm text-muted-foreground">
-                    No categories available.
+          <div className="flex-1 overflow-y-auto pr-1 sm:pr-0">
+            <div className="space-y-6">
+              <div className="space-y-4">
+                <div>
+                  <h3 className="text-sm font-medium text-foreground">Categories</h3>
+                  <p className="text-xs text-muted-foreground">
+                    Choose one or multiple categories to narrow down results.
                   </p>
-                )}
+                </div>
+                <ScrollArea className="max-h-[60vh] rounded-2xl border border-white/60 bg-white/70 p-3 shadow-inner backdrop-blur dark:border-white/10 dark:bg-slate-950/60 sm:max-h-64">
+                  <div className="space-y-3">
+                    {isLoading ? (
+                      <div className="space-y-3">
+                        {Array.from({ length: 5 }).map((_, index) => (
+                          <div
+                            key={index}
+                            className="h-10 animate-pulse rounded-lg bg-muted/60"
+                          />
+                        ))}
+                      </div>
+                    ) : categories && categories.length > 0 ? (
+                      categories.map((category) => {
+                        const isChecked = selectedCategoryIds.includes(category.id);
+                        return (
+                          <Label
+                            key={category.id}
+                            htmlFor={`filter-category-${category.id}`}
+                            className={cn(
+                              "flex cursor-pointer items-center gap-3 rounded-xl border border-transparent px-3 py-2 text-sm font-medium text-foreground transition-colors hover:border-primary/30 hover:bg-primary/5 hover:text-primary",
+                              isChecked &&
+                                "border-primary/40 bg-primary/10 text-primary shadow-sm dark:border-primary/30 dark:bg-primary/15 dark:text-primary-foreground"
+                            )}
+                          >
+                            <Checkbox
+                              id={`filter-category-${category.id}`}
+                              checked={isChecked}
+                              onCheckedChange={(value) =>
+                                toggleCategory(category.id, value === true)
+                              }
+                            />
+                            <span className="font-medium text-foreground">
+                              {category.name}
+                            </span>
+                          </Label>
+                        );
+                      })
+                    ) : (
+                      <p className="text-sm text-muted-foreground">
+                        No categories available.
+                      </p>
+                    )}
+                  </div>
+                </ScrollArea>
               </div>
-            </ScrollArea>
+
+              <div className="space-y-4">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <h3 className="text-sm font-medium text-foreground">Date range</h3>
+                    <p className="text-xs text-muted-foreground">
+                      Select a start and end date to filter transactions.
+                    </p>
+                  </div>
+                  {(filters.dateRange?.from || filters.dateRange?.to) && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-8 px-2 text-xs"
+                      onClick={clearDateRange}
+                    >
+                      Clear
+                    </Button>
+                  )}
+                </div>
+                <div className="rounded-2xl border border-white/60 bg-white/70 p-3 shadow-inner backdrop-blur dark:border-white/10 dark:bg-slate-950/60">
+                  <Calendar
+                    mode="range"
+                    numberOfMonths={1}
+                    selected={filters.dateRange}
+                    onSelect={(range) =>
+                      setFilters((previous) => ({
+                        ...previous,
+                        dateRange: range,
+                      }))
+                    }
+                  />
+                </div>
+              </div>
+            </div>
           </div>
 
-          <div className="space-y-4">
-            <div className="flex items-center justify-between">
-              <div>
-                <h3 className="text-sm font-medium text-foreground">Date range</h3>
-                <p className="text-xs text-muted-foreground">
-                  Select a start and end date to filter transactions.
-                </p>
-              </div>
-              {(filters.dateRange?.from || filters.dateRange?.to) && (
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="h-8 px-2 text-xs"
-                  onClick={clearDateRange}
-                >
-                  Clear
-                </Button>
-              )}
-            </div>
-            <div className="rounded-2xl border border-white/60 bg-white/70 p-3 shadow-inner backdrop-blur dark:border-white/10 dark:bg-slate-950/60">
-              <Calendar
-                mode="range"
-                numberOfMonths={1}
-                selected={filters.dateRange}
-                onSelect={(range) =>
-                  setFilters((previous) => ({
-                    ...previous,
-                    dateRange: range,
-                  }))
-                }
-              />
-            </div>
-          </div>
+          <SheetFooter className="mt-4 shrink-0 pt-2">
+            <Button
+              variant="outline"
+              className="justify-center"
+              onClick={() => {
+                resetFilters();
+              }}
+            >
+              Reset filters
+            </Button>
+            <Button onClick={() => onOpenChange(false)}>Apply filters</Button>
+          </SheetFooter>
         </div>
-
-        <SheetFooter className="pt-2">
-          <Button
-            variant="outline"
-            className="justify-center"
-            onClick={() => {
-              resetFilters();
-            }}
-          >
-            Reset filters
-          </Button>
-          <Button onClick={() => onOpenChange(false)}>Apply filters</Button>
-        </SheetFooter>
       </SheetContent>
     </Sheet>
   );

--- a/client/src/components/sidebar.tsx
+++ b/client/src/components/sidebar.tsx
@@ -176,7 +176,7 @@ export function Sidebar({ collapsed, onToggle }: SidebarProps) {
                       className={cn(
                         "flex h-11 w-11 items-center justify-center rounded-2xl border border-white/60 bg-white/80 text-primary shadow-sm backdrop-blur transition-all dark:border-white/10 dark:bg-slate-900/70",
                         isActive &&
-                          "border-primary/40 bg-primary/15 text-primary shadow-md dark:border-primary/50 dark:bg-primary/20 dark:text-white"
+                          "border-primary/40 bg-primary/15 text-primary shadow-md dark:border-primary/50 dark:bg-primary/20"
                       )}
                     >
                       <Icon className="h-5 w-5" />

--- a/client/src/components/sidebar.tsx
+++ b/client/src/components/sidebar.tsx
@@ -161,7 +161,7 @@ export function Sidebar({ collapsed, onToggle }: SidebarProps) {
                         ? "justify-center gap-0 px-2 py-3"
                         : "gap-3 px-4 py-3",
                       isActive
-                        ? "border-primary/40 bg-white/90 text-primary shadow-[0_18px_40px_rgba(99,102,241,0.18)] dark:border-primary/30 dark:bg-gradient-to-r dark:from-primary/90 dark:via-primary/80 dark:to-primary/60 dark:text-white dark:shadow-[0_18px_40px_rgba(99,102,241,0.45)]"
+                        ? "border-primary/40 bg-white/90 text-primary shadow-[0_18px_40px_rgba(99,102,241,0.18)] dark:border-primary/40 dark:bg-slate-900/75 dark:text-white dark:shadow-[0_18px_40px_rgba(15,23,42,0.55)]"
                         : "text-muted-foreground hover:border-white/60 hover:bg-white/70 hover:text-foreground dark:hover:border-white/15 dark:hover:bg-white/10"
                     )}
                   >
@@ -176,7 +176,7 @@ export function Sidebar({ collapsed, onToggle }: SidebarProps) {
                       className={cn(
                         "flex h-11 w-11 items-center justify-center rounded-2xl border border-white/60 bg-white/80 text-primary shadow-sm backdrop-blur transition-all dark:border-white/10 dark:bg-slate-900/70",
                         isActive &&
-                          "border-primary/40 bg-primary/15 text-primary shadow-md dark:border-transparent dark:bg-white/10 dark:text-white dark:shadow-none"
+                          "border-primary/40 bg-primary/15 text-primary shadow-md dark:border-primary/50 dark:bg-primary/20 dark:text-white"
                       )}
                     >
                       <Icon className="h-5 w-5" />
@@ -192,7 +192,7 @@ export function Sidebar({ collapsed, onToggle }: SidebarProps) {
                       {item.name}
                     </span>
                     {isActive && !collapsed ? (
-                      <span className="ml-auto h-2 w-2 rounded-full bg-primary shadow dark:bg-white/80" />
+                      <span className="ml-auto h-2 w-2 rounded-full bg-primary shadow dark:bg-primary/60" />
                     ) : null}
                   </Link>
                 </TooltipTrigger>

--- a/client/src/components/sidebar.tsx
+++ b/client/src/components/sidebar.tsx
@@ -161,7 +161,7 @@ export function Sidebar({ collapsed, onToggle }: SidebarProps) {
                         ? "justify-center gap-0 px-2 py-3"
                         : "gap-3 px-4 py-3",
                       isActive
-                        ? "border-primary/30 bg-gradient-to-r from-primary/90 via-primary/80 to-primary/60 text-white shadow-lg shadow-primary/30"
+                        ? "border-primary/40 bg-white/90 text-primary shadow-[0_18px_40px_rgba(99,102,241,0.18)] dark:border-primary/30 dark:bg-gradient-to-r dark:from-primary/90 dark:via-primary/80 dark:to-primary/60 dark:text-white dark:shadow-[0_18px_40px_rgba(99,102,241,0.45)]"
                         : "text-muted-foreground hover:border-white/60 hover:bg-white/70 hover:text-foreground dark:hover:border-white/15 dark:hover:bg-white/10"
                     )}
                   >
@@ -176,7 +176,7 @@ export function Sidebar({ collapsed, onToggle }: SidebarProps) {
                       className={cn(
                         "flex h-11 w-11 items-center justify-center rounded-2xl border border-white/60 bg-white/80 text-primary shadow-sm backdrop-blur transition-all dark:border-white/10 dark:bg-slate-900/70",
                         isActive &&
-                          "border-transparent bg-white/20 text-white shadow-none dark:bg-white/10"
+                          "border-primary/40 bg-primary/15 text-primary shadow-md dark:border-transparent dark:bg-white/10 dark:text-white dark:shadow-none"
                       )}
                     >
                       <Icon className="h-5 w-5" />
@@ -192,7 +192,7 @@ export function Sidebar({ collapsed, onToggle }: SidebarProps) {
                       {item.name}
                     </span>
                     {isActive && !collapsed ? (
-                      <span className="ml-auto h-2 w-2 rounded-full bg-white/80 shadow" />
+                      <span className="ml-auto h-2 w-2 rounded-full bg-primary shadow dark:bg-white/80" />
                     ) : null}
                   </Link>
                 </TooltipTrigger>

--- a/client/src/components/stats-cards.tsx
+++ b/client/src/components/stats-cards.tsx
@@ -221,7 +221,7 @@ export function StatsCards() {
                     <span className="text-muted-foreground">{trendNote}</span>
                   </div>
                   {meta ? (
-                    <p className="mt-2 w-full text-left text-xs text-muted-foreground/90 sm:text-center">
+                    <p className="mt-2 w-full text-left text-xs text-muted-foreground/90">
                       {meta}
                     </p>
                   ) : (

--- a/client/src/components/ui/sheet.tsx
+++ b/client/src/components/ui/sheet.tsx
@@ -38,9 +38,10 @@ const sheetVariants = cva(
         top: "inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
         bottom:
           "inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
-        left: "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
+        left:
+          "inset-y-0 left-0 h-full w-full border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-md",
         right:
-          "inset-y-0 right-0 h-full w-3/4  border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
+          "inset-y-0 right-0 h-full w-full border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-md",
       },
     },
     defaultVariants: {


### PR DESCRIPTION
## Summary
- refresh the expense filter sheet with full-width mobile layout, glassmorphism styling, and clearer selected states
- adjust the base sheet component so side drawers occupy the full viewport width on small screens
- tune the light theme sidebar active state with softer colors and consistent icon/dot styling while preserving dark theme contrast

## Testing
- npm run lint *(fails: ESLint could not find an eslint.config file in this repo)*

------
https://chatgpt.com/codex/tasks/task_e_68d64f5fe2888321a204319431aa5a4f