### PR TITLE
Improve modal appearance for light theme and toast close visibility

### DIFF
--- a/client/src/components/add-expense-modal.tsx
+++ b/client/src/components/add-expense-modal.tsx
@@ -120,7 +120,7 @@ export function AddExpenseModal({ children }: AddExpenseModalProps) {
                         type="number"
                         step="0.01"
                         placeholder="0.00"
-                        className="rounded-2xl border border-white/60 bg-white/85 pl-9 pr-4 dark:border-white/10 dark:bg-slate-900/70"
+                        className="rounded-2xl border border-slate-200 bg-white/95 pl-9 pr-4 text-slate-900 shadow-sm transition focus-visible:border-primary/40 focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-primary/10 dark:border-white/10 dark:bg-slate-900/70 dark:text-slate-100 dark:focus-visible:ring-primary/20"
                         data-testid="input-amount"
                         {...field}
                       />
@@ -139,7 +139,7 @@ export function AddExpenseModal({ children }: AddExpenseModalProps) {
                   <FormLabel>Category</FormLabel>
                   <Select onValueChange={field.onChange} defaultValue={field.value}>
                     <FormControl>
-                      <SelectTrigger className="rounded-2xl border-white/60 bg-white/85 dark:border-white/10 dark:bg-slate-900/70" data-testid="select-category">
+                      <SelectTrigger className="rounded-2xl border border-slate-200 bg-white/95 text-slate-900 shadow-sm transition focus-visible:border-primary/40 focus-visible:ring-4 focus-visible:ring-primary/10 dark:border-white/10 dark:bg-slate-900/70 dark:text-slate-100" data-testid="select-category">
                         <SelectValue placeholder="Select category" />
                       </SelectTrigger>
                     </FormControl>
@@ -171,7 +171,7 @@ export function AddExpenseModal({ children }: AddExpenseModalProps) {
                   <FormControl>
                     <Input
                       placeholder="Enter expense description"
-                      className="rounded-2xl border border-white/60 bg-white/85 dark:border-white/10 dark:bg-slate-900/70"
+                      className="rounded-2xl border border-slate-200 bg-white/95 text-slate-900 shadow-sm transition focus-visible:border-primary/40 focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-primary/10 dark:border-white/10 dark:bg-slate-900/70 dark:text-slate-100"
                       data-testid="input-description"
                       {...field}
                     />
@@ -190,7 +190,7 @@ export function AddExpenseModal({ children }: AddExpenseModalProps) {
                   <FormControl>
                     <Input
                       type="date"
-                      className="rounded-2xl border border-white/60 bg-white/85 dark:border-white/10 dark:bg-slate-900/70"
+                      className="rounded-2xl border border-slate-200 bg-white/95 text-slate-900 shadow-sm transition focus-visible:border-primary/40 focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-primary/10 dark:border-white/10 dark:bg-slate-900/70 dark:text-slate-100"
                       data-testid="input-date"
                       {...field}
                       value={

--- a/client/src/components/mobile-nav.tsx
+++ b/client/src/components/mobile-nav.tsx
@@ -70,7 +70,6 @@ export function MobileNav() {
           </Button>
           <div>
             <p className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.35em] text-muted-foreground">
-              <Sparkles className="h-4 w-4 text-primary" />
               DollarTrack
             </p>
             <p className="text-sm text-muted-foreground/80">

--- a/client/src/components/ui/modal.tsx
+++ b/client/src/components/ui/modal.tsx
@@ -18,7 +18,7 @@ const ModalOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 bg-slate-950/70 backdrop-blur-xl transition-all data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=closed]:animate-out data-[state=closed]:fade-out-0",
+      "fixed inset-0 z-50 bg-slate-900/30 backdrop-blur-xl transition-all data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 dark:bg-slate-950/70",
       className
     )}
     {...props}
@@ -35,18 +35,23 @@ const ModalContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "group fixed left-1/2 top-1/2 z-50 w-[min(95vw,560px)] -translate-x-1/2 -translate-y-1/2 overflow-hidden rounded-[32px] border border-white/25 bg-gradient-to-br from-white/98 via-white/90 to-white/80 p-0 text-foreground shadow-[0_32px_90px_-30px_rgba(15,23,42,0.6)] ring-1 ring-white/40 backdrop-blur-2xl transition-all data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-90 dark:border-white/10 dark:from-slate-950/95 dark:via-slate-950/85 dark:to-slate-950/80 dark:ring-white/10",
-        "before:pointer-events-none before:absolute before:-inset-px before:-z-10 before:rounded-[inherit] before:bg-gradient-to-br before:from-white/70 before:via-white/20 before:to-white/10 before:opacity-80 before:blur-3xl before:content-[''] dark:before:from-slate-900/70 dark:before:via-slate-900/40 dark:before:to-slate-900/20",
+        "group fixed left-1/2 top-1/2 z-50 w-[min(95vw,560px)] -translate-x-1/2 -translate-y-1/2 overflow-hidden rounded-[28px] border border-slate-200/80 bg-white/95 p-0 text-slate-900 shadow-[0_32px_80px_-28px_rgba(15,23,42,0.35)] ring-1 ring-black/5 backdrop-blur-2xl transition-all data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-90 dark:border-white/10 dark:bg-slate-950/90 dark:text-slate-100 dark:ring-white/10",
+        "before:pointer-events-none before:absolute before:-inset-px before:-z-10 before:rounded-[inherit] before:bg-gradient-to-br before:from-white/90 before:via-white/40 before:to-white/20 before:opacity-70 before:blur-3xl before:content-[''] dark:before:from-slate-900/70 dark:before:via-slate-900/40 dark:before:to-slate-900/20",
         className
       )}
       {...props}
     >
-      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.45),transparent_65%)] opacity-80 dark:bg-[radial-gradient(circle_at_top,rgba(148,163,184,0.3),transparent_70%)]" />
-      <div className="relative z-10 flex flex-col gap-6 p-8">{children}</div>
-      <DialogPrimitive.Close className="absolute right-5 top-5 inline-flex h-9 w-9 items-center justify-center rounded-full border border-white/40 bg-white/80 text-slate-600 shadow-sm transition hover:-translate-y-[1px] hover:bg-white dark:border-white/10 dark:bg-slate-900/70 dark:text-slate-200 dark:hover:bg-slate-900">
-        <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
-      </DialogPrimitive.Close>
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(148,163,184,0.25),transparent_65%)] opacity-70 dark:bg-[radial-gradient(circle_at_top,rgba(148,163,184,0.3),transparent_70%)]" />
+      <div className="relative z-10 flex flex-col gap-6 p-8 pr-12 sm:pr-14">
+        <DialogPrimitive.Close
+          className="absolute right-6 top-6 inline-flex h-9 w-9 items-center justify-center rounded-full border border-slate-200/90 bg-white/90 text-slate-500 shadow-sm transition hover:-translate-y-[1px] hover:bg-slate-100 hover:text-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:border-white/10 dark:bg-slate-900/70 dark:text-slate-200 dark:hover:bg-slate-900 dark:focus-visible:ring-offset-slate-950"
+          type="button"
+        >
+          <X className="h-4 w-4" />
+          <span className="sr-only">Close</span>
+        </DialogPrimitive.Close>
+        {children}
+      </div>
     </DialogPrimitive.Content>
   </ModalPortal>
 ));

--- a/client/src/components/ui/toast.tsx
+++ b/client/src/components/ui/toast.tsx
@@ -75,7 +75,7 @@ const ToastClose = React.forwardRef<
   <ToastPrimitives.Close
     ref={ref}
     className={cn(
-      "absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600",
+      "absolute right-2.5 top-2.5 inline-flex h-8 w-8 items-center justify-center rounded-full bg-muted/30 text-muted-foreground transition hover:bg-muted/50 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background group-[.destructive]:bg-red-500/20 group-[.destructive]:text-red-100 group-[.destructive]:hover:bg-red-500/35 group-[.destructive]:hover:text-red-50",
       className
     )}
     toast-close=""


### PR DESCRIPTION
## Summary
- refine modal overlay and content styling for light theme clarity and reposition the close control for consistent dismissal
- update add expense modal inputs and select to use higher contrast borders and focus states in the light theme
- adjust toast close button styling so the notification dismiss icon remains visible across themes

## Testing
- npm run lint *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68d91172bce88321b764f5d6a01ea064